### PR TITLE
Fix number of overall results

### DIFF
--- a/thoth/storages/graph/dgraph.py
+++ b/thoth/storages/graph/dgraph.py
@@ -2132,7 +2132,7 @@ class GraphDatabase(StorageBase):
 
         # Output stack.
         for idx, result in enumerate(document["result"]["report"]):
-            if len(result) != 2:
+            if len(result) != 3:
                 _LOGGER.error("Omitting stack as no output Pipfile.lock was provided")
                 continue
 


### PR DESCRIPTION
There are present three values not just two - justification, stack
(requirements and requirements locked) and overall stack score.