### PR TITLE
Provide OS version and name as a string

### DIFF
--- a/thoth/storages/graph/dgraph.py
+++ b/thoth/storages/graph/dgraph.py
@@ -646,13 +646,13 @@ class GraphDatabase(StorageBase):
 
         q = ""
         if os_name:
-            q = q + " AND eq(os_name, %s)" % os_name
+            q = q + ' AND eq(os_name, "%s")' % os_name
 
         if os_version:
-            q = q + " AND eq(os_version, %s)" % os_version
+            q = q + ' AND eq(os_version, "%s")' % os_version
 
         if python_version:
-            q = q + " AND eq(python_version, %s)" % python_version
+            q = q + ' AND eq(python_version, "%s")' % python_version
 
         if without_error:
             q = q + " AND eq(solver_error, %s)" % False


### PR DESCRIPTION
Let's encapsulate properties into strings so that queries do not introduce
syntax erros in case of non-alphabeticall characters.

Fixes: #727