### PR TITLE
New tests for inspection schema check before sync

### DIFF
--- a/thoth/storages/inspection_schema.py
+++ b/thoth/storages/inspection_schema.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# thoth-storages
+# Copyright(C) 2019 Fridolin Pokorny, Francesco Murdaca
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Schema definition for inspection results."""
+
+from voluptuous import Required
+from voluptuous import Schema
+from .result_schema import Datetime
+
+
+# Metadata about specifications produced by inspections.
+INSPECTION_SPECIFICATION_SCHEMA = Schema(
+    {
+        Required("specification"): list,
+    }
+)
+
+
+# Metadata about created produced by inspections.
+INSPECTION_CREATED_SCHEMA = Schema(
+    {
+        Required("created"): Datetime(),
+    }
+)
+
+
+# Metadata about build_log produced by inspections.
+INSPECTION_BUILD_LOG_SCHEMA = Schema(
+    {
+        Required("build_log"): str,
+    }
+)
+
+
+# Metadata about job_log produced by inspections.
+INSPECTION_JOB_LOG_SCHEMA = Schema(
+    {
+        Required("job_log"): list,
+    }
+)
+
+
+# Metadata about inspection_id produced by inspections.
+INSPECTION_INSPECTION_ID_SCHEMA = Schema(
+    {
+        Required("inspection_id"): str,
+    }
+)
+
+
+# Metadata about status produced by inspections.
+INSPECTION_STATUS_SCHEMA = Schema(
+    {
+        Required("status"): list,
+    }
+)
+
+
+# Metadata inspections.
+INSPECTION_SCHEMA = Schema(
+    {
+        Required("specification"): INSPECTION_SPECIFICATION_SCHEMA,
+        Required("created"): INSPECTION_CREATED_SCHEMA,
+        Required("build_log"): INSPECTION_BUILD_LOG_SCHEMA,
+        Required("job_log"): INSPECTION_JOB_LOG_SCHEMA,
+        Required("inspection_id"): INSPECTION_INSPECTION_ID_SCHEMA,
+        Required("status"): INSPECTION_STATUS_SCHEMA,
+    }
+)

--- a/thoth/storages/inspections.py
+++ b/thoth/storages/inspections.py
@@ -18,13 +18,14 @@
 """Adapter for persisting Amun inspection results."""
 
 from .result_base import ResultStorageBase
+from .inspection_schema import INSPECTION_SCHEMA
 
 
 class InspectionResultsStore(ResultStorageBase):
     """Adapter for persisting Amun inspection results."""
 
     RESULT_TYPE = "inspection"
-    SCHEMA = None
+    SCHEMA = INSPECTION_SCHEMA
 
     @classmethod
     def get_document_id(cls, document: dict) -> str:

--- a/thoth/storages/sync.py
+++ b/thoth/storages/sync.py
@@ -251,7 +251,7 @@ def sync_inspection_documents(
     only_ceph_sync: bool = False,
     graph: GraphDatabase = None,
 ) -> tuple:
-    """Sync observations made on Amun into graph databaes."""
+    """Sync observations made on Amun into graph database."""
     if only_graph_sync and only_ceph_sync:
         raise ValueError("At least one of Ceph or Graph should be performed")
 


### PR DESCRIPTION
Using https://github.com/alecthomas/voluptuous as suggested by @fridex, validation tests for the schema result of an inspection have been created. In this way we are able to check that the correct output is produced during an inspection before it can be stored on Ceph.

Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>