### PR TITLE
Use index for int values of performance indicators

### DIFF
--- a/thoth/storages/graph/models.py
+++ b/thoth/storages/graph/models.py
@@ -438,18 +438,18 @@ class HardwareInformation(VertexBase):
     """Hardware specification and properties."""
 
     cpu_vendor = model_property(type=str, index="exact")
-    cpu_model = model_property(type=int)
-    cpu_cores = model_property(type=int)
-    cpu_model_name = model_property(type=str)
-    cpu_family = model_property(type=int)
-    cpu_physical_cpus = model_property(type=int)
+    cpu_model = model_property(type=int, index="int")
+    cpu_cores = model_property(type=int, index="int")
+    cpu_model_name = model_property(type=str, index="exact")
+    cpu_family = model_property(type=int, index="int")
+    cpu_physical_cpus = model_property(type=int, index="int")
 
     gpu_model_name = model_property(type=str, index="exact")
-    gpu_vendor = model_property(type=str)
-    gpu_cores = model_property(type=int)
-    gpu_memory_size = model_property(type=float)
+    gpu_vendor = model_property(type=str, index="exact")
+    gpu_cores = model_property(type=int, index="int")
+    gpu_memory_size = model_property(type=float, index="float")
 
-    ram_size = model_property(type=float)
+    ram_size = model_property(type=float, index="float")
 
 
 @attr.s(slots=True)

--- a/thoth/storages/graph/schema.rdf
+++ b/thoth/storages/graph/schema.rdf
@@ -71,16 +71,16 @@ solver_name: string @index(exact) .
 solver_version: string @index(exact) .
 hardware_information_label: string @count @upsert @index(exact) .
 cpu_vendor: string @index(exact) .
-cpu_model: int .
-cpu_cores: int .
-cpu_model_name: string .
-cpu_family: int .
-cpu_physical_cpus: int .
+cpu_model: int @index(int) .
+cpu_cores: int @index(int) .
+cpu_model_name: string @index(exact) .
+cpu_family: int @index(int) .
+cpu_physical_cpus: int @index(int) .
 gpu_model_name: string @index(exact) .
-gpu_vendor: string .
-gpu_cores: int .
-gpu_memory_size: float .
-ram_size: float .
+gpu_vendor: string @index(exact) .
+gpu_cores: int @index(int) .
+gpu_memory_size: float @index(float) .
+ram_size: float @index(float) .
 has_artifact_label: string @count @upsert @index(exact) .
 has_artifact: uid @reverse @count .
 has_vulnerability_label: string @count @upsert @index(exact) .


### PR DESCRIPTION
We need to have these values indexed as they are queried when in adviser
pipelines.