### PR TITLE
PackageAnalysisResultsStore is added

### DIFF
--- a/thoth/storages/__init__.py
+++ b/thoth/storages/__init__.py
@@ -37,6 +37,7 @@ from .sync import sync_inspection_documents
 from .sync import sync_provenance_checker_documents
 from .sync import sync_dependency_monkey_documents
 from .analyses_by_digest import AnalysisByDigest
+from .package_analyses import PackageAnalysisResultsStore
 
 
 __name__ = "thoth-storages"

--- a/thoth/storages/package_analyses.py
+++ b/thoth/storages/package_analyses.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# thoth-storages
+# Copyright(C) 2018, 2019 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Adapter for storing package analysis results onto a persistence remote store."""
+
+from .result_base import ResultStorageBase
+
+
+class PackageAnalysisResultsStore(ResultStorageBase):
+    """Store results of package analyzes."""
+
+    RESULT_TYPE = "package-analysis"
+    SCHEMA = None


### PR DESCRIPTION
This is the directory where package analyzer results will be stored on ceph.