### PR TITLE
Change log error to warning

### DIFF
--- a/thoth/storages/graph/dgraph.py
+++ b/thoth/storages/graph/dgraph.py
@@ -2293,7 +2293,7 @@ class GraphDatabase(StorageBase):
         # Output stack.
         for idx, result in enumerate(document["result"]["report"]):
             if len(result) != 3:
-                _LOGGER.error("Omitting stack as no output Pipfile.lock was provided")
+                _LOGGER.warning("Omitting stack as no output Pipfile.lock was provided")
                 continue
 
             # result[0] is score report


### PR DESCRIPTION
The message "Omitting stack as no output Pipfile.lock was provided" should be a warning