### PR TITLE
Fix default value to environment variable

### DIFF
--- a/thoth/storages/graph/dgraph.py
+++ b/thoth/storages/graph/dgraph.py
@@ -248,7 +248,7 @@ class GraphDatabase(StorageBase):
         assert self._client is not None, "Adapter is not connected to any Dgraph instance."
         txn = self._client.txn(read_only=read_only)
 
-        if bool(int(os.getenv("THOTH_STORAGES_DEBUG_QUERIES"))):
+        if bool(int(os.getenv("THOTH_STORAGES_DEBUG_QUERIES", 0))):
             _LOGGER.debug("Performing query with variables (read_only=%r): %r\n%s", read_only, variables, query)
 
         try:


### PR DESCRIPTION
... otherwise the casting will fail due to None value.