### PR TITLE
New query for number of versions per Python package name

### DIFF
--- a/thoth/storages/graph/models.py
+++ b/thoth/storages/graph/models.py
@@ -50,9 +50,9 @@ class PythonPackageVersion(Base, BaseExtension):
     package_version = Column(String(256), nullable=False)
     # Nullable if we have unparseable entries or entries comming from package-extract where we
     # were unable to detect these entries.
-    os_name = Column(String(256))
-    os_version = Column(String(256))
-    python_version = Column(String(256))
+    os_name = Column(String(256), nullable=True)
+    os_version = Column(String(256), nullable=True)
+    python_version = Column(String(256), nullable=True)
     entity_id = Column(Integer, ForeignKey("python_package_version_entity.id", ondelete="CASCADE"), nullable=False)
     # Null if cannot parse.
     python_package_index_id = Column(Integer, ForeignKey("python_package_index.id", ondelete="CASCADE"), nullable=True)

--- a/thoth/storages/graph/models.py
+++ b/thoth/storages/graph/models.py
@@ -50,9 +50,9 @@ class PythonPackageVersion(Base, BaseExtension):
     package_version = Column(String(256), nullable=False)
     # Nullable if we have unparseable entries or entries comming from package-extract where we
     # were unable to detect these entries.
-    os_name = Column(String(256), nullable=True)
-    os_version = Column(String(256), nullable=True)
-    python_version = Column(String(256), nullable=True)
+    os_name = Column(String(256))
+    os_version = Column(String(256))
+    python_version = Column(String(256))
     entity_id = Column(Integer, ForeignKey("python_package_version_entity.id", ondelete="CASCADE"), nullable=False)
     # Null if cannot parse.
     python_package_index_id = Column(Integer, ForeignKey("python_package_index.id", ondelete="CASCADE"), nullable=True)

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -1241,15 +1241,18 @@ class GraphDatabase(SQLBase):
         start_offset: int = 0,
         count: int = 10,
         os_name: str = None,
-        os_version: str =None,
+        os_version: str = None,
         python_version: str = None,
-        distinct: bool=False,
+        distinct: bool = False,
     ) -> List[Tuple[str, str, str]]:
         """Retrieve Python package versions in Thoth Database."""
         query = (
             self._session.query(PythonPackageVersion)
             .join(PythonPackageIndex)
-            .with_entities(PythonPackageVersion.package_name, PythonPackageVersion.package_version, PythonPackageIndex.url.isnot(None))
+            .with_entities(
+                PythonPackageVersion.package_name,
+                PythonPackageVersion.package_version,
+                PythonPackageIndex.url)
             )
 
         if os_name is not None:

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -1264,7 +1264,46 @@ class GraphDatabase(SQLBase):
         if python_version is not None:
             query = query.filter(PythonPackageVersion.python_version == python_version)
 
-        query = query.offset(start_offset).limit(count).all()
+        query = query.offset(start_offset).limit(count)
+
+        if distinct:
+            query.distinct()
+
+        query = query.all()
+
+        return query
+
+    def get_python_package_versions_count_all(
+        self,
+        *,
+        os_name: str = None,
+        os_version: str = None,
+        python_version: str = None,
+        distinct: bool = False,
+    ) -> int:
+        """Retrieve Python package versions number in Thoth Database."""
+        query = (
+            self._session.query(PythonPackageVersion)
+            .join(PythonPackageIndex)
+            .with_entities(
+                PythonPackageVersion.package_name,
+                PythonPackageVersion.package_version,
+                PythonPackageIndex.url)
+            )
+
+        if os_name is not None:
+            query = query.filter(PythonPackageVersion.os_name == os_name)
+
+        if os_version is not None:
+            query = query.filter(PythonPackageVersion.os_version == os_version)
+
+        if python_version is not None:
+            query = query.filter(PythonPackageVersion.python_version == python_version)
+
+        if distinct:
+            query = query.distinct()
+
+        query = query.count()
 
         return query
 

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -1235,17 +1235,13 @@ class GraphDatabase(SQLBase):
 
         return {(item[0], item[1], item[2]): item[3] for item in query}
 
-    def get_python_package_versions_count_all(
+    def _construct_python_package_versions_query(
         self,
-        *,
-        start_offset: int = 0,
-        count: int = 10,
         os_name: str = None,
         os_version: str = None,
-        python_version: str = None,
-        distinct: bool = False,
-    ) -> List[Tuple[str, str, str]]:
-        """Retrieve Python package versions in Thoth Database."""
+        python_version: str = None
+    ) -> Query:
+        """Construct query for Python packages versions functions, the query is not executed."""
         query = (
             self._session.query(PythonPackageVersion)
             .join(PythonPackageIndex)
@@ -1263,6 +1259,25 @@ class GraphDatabase(SQLBase):
 
         if python_version is not None:
             query = query.filter(PythonPackageVersion.python_version == python_version)
+
+        return query
+
+    def get_python_package_versions(
+        self,
+        *,
+        start_offset: int = 0,
+        count: int = 10,
+        os_name: str = None,
+        os_version: str = None,
+        python_version: str = None,
+        distinct: bool = False,
+    ) -> List[Tuple[str, str, str]]:
+        """Retrieve Python package versions in Thoth Database."""
+        query = self._construct_python_package_versions_query(
+            os_name=os_name,
+            os_version=os_version,
+            python_version=python_version
+            )
 
         query = query.offset(start_offset).limit(count)
 
@@ -1282,23 +1297,11 @@ class GraphDatabase(SQLBase):
         distinct: bool = False,
     ) -> int:
         """Retrieve Python package versions number in Thoth Database."""
-        query = (
-            self._session.query(PythonPackageVersion)
-            .join(PythonPackageIndex)
-            .with_entities(
-                PythonPackageVersion.package_name,
-                PythonPackageVersion.package_version,
-                PythonPackageIndex.url)
+        query = self._construct_python_package_versions_query(
+            os_name=os_name,
+            os_version=os_version,
+            python_version=python_version
             )
-
-        if os_name is not None:
-            query = query.filter(PythonPackageVersion.os_name == os_name)
-
-        if os_version is not None:
-            query = query.filter(PythonPackageVersion.os_version == os_version)
-
-        if python_version is not None:
-            query = query.filter(PythonPackageVersion.python_version == python_version)
 
         if distinct:
             query = query.distinct()

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -1238,19 +1238,18 @@ class GraphDatabase(SQLBase):
     def get_python_package_versions_count_all(
         self,
         *,
+        start_offset: int = 0,
+        count: int = 10,
         os_name: str = None,
-        os_version: str = None,
+        os_version: str =None,
         python_version: str = None,
-        distinct: bool = False,
-    ) -> int:
-        """Retrieve Python package versions number in Thoth Database."""
+        distinct: bool=False,
+    ) -> List[Tuple[str, str, str]]:
+        """Retrieve Python package versions in Thoth Database."""
         query = (
             self._session.query(PythonPackageVersion)
             .join(PythonPackageIndex)
-            .with_entities(
-                PythonPackageVersion.package_name,
-                PythonPackageVersion.package_version,
-                PythonPackageIndex.url)
+            .with_entities(PythonPackageVersion.package_name, PythonPackageVersion.package_version, PythonPackageIndex.url.isnot(None))
             )
 
         if os_name is not None:
@@ -1262,10 +1261,7 @@ class GraphDatabase(SQLBase):
         if python_version is not None:
             query = query.filter(PythonPackageVersion.python_version == python_version)
 
-        if distinct:
-            query = query.distinct()
-
-        query = query.count()
+        query = query.offset(start_offset).limit(count).all()
 
         return query
 


### PR DESCRIPTION
- Created new query for python package versions
- Modified attributes for `PythonPackageVersion` shall always have os_name, os_version, python_version provided during syncs
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>