### PR TITLE
Generic webhook updated to trigger the build from zuul

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -15,7 +15,9 @@
       jobs:
         - trigger-build:
             vars:
-              webhook_url: https://paas.upshift.redhat.com/oapi/v1/namespaces/thoth-test-core/buildconfigs/user-api
+              cluster: "paas.psi.redhat.com"
+              namespace: "thoth-test-core"
+              buildConfigName: "user-api"
     kebechet-auto-gate:
       queue: thoth-station/core
       jobs:


### PR DESCRIPTION
Generic webhook updated to trigger the build from zuul

Fixes: **trigger-build https://managesf.thoth-station.ninja/logs/15/1551842b300b63296b48777782a0229da78cdcbb/post/trigger-build/e3f5a55/ : FAILURE in 1m 01s**

Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>