### PR TITLE
HasArtifact is linked with PythonPackageVersionEntity table

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -2942,16 +2942,16 @@ class GraphDatabase(SQLBase):
             query = (
                 self._session.query(PythonPackageIndex)
                 .filter(PythonPackageIndex.url == index_url)
-                .join(PythonPackageVersion)
+                .join(PythonPackageVersionEntity)
             )
         else:
-            query = self._session.query(PythonPackageVersion)
+            query = self._session.query(PythonPackageVersionEntity)
 
         query = (
-            query.filter(PythonPackageVersion.package_name == package_name)
-            .filter(PythonPackageVersion.package_version == package_version)
-            .join((HasArtifact, PythonPackageVersion.python_artifacts))
-            .join((PythonArtifact, HasArtifact.python_artifact))
+            query.filter(PythonPackageVersionEntity.package_name == package_name)
+            .filter(PythonPackageVersionEntity.package_version == package_version)
+            .join(HasArtifact)
+            .join(PythonArtifact)
             .with_entities(PythonArtifact.artifact_hash_sha256)
             .distinct()
         )


### PR DESCRIPTION
This fixes error during retrieval of hashes when there is queried
PythonPackageVersion table, but this table has no relation to HasArtifact
table.