### PR TITLE
Pick metadata which were computed

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -3766,6 +3766,7 @@ class GraphDatabase(SQLBase):
             .filter(PythonPackageVersion.package_name == package_name)
             .filter(PythonPackageVersion.package_version == package_version)
             .filter(PythonPackageIndex.url == index_url)
+            .filter(PythonPackageVersion.python_package_metadata_id.isnot(None))
         )
 
         result = query.first()


### PR DESCRIPTION
We might get into an issue when metadata cannot be gathered because of
installation issues into the given software environment. This patch addresses
such issue and always tries to pick metadata of a package that were
successfully gathered.