### PR TITLE
Use default pooling from sqlalchemy

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -41,7 +41,6 @@ from sqlalchemy import or_
 from sqlalchemy.orm import Query
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.pool import NullPool
 from sqlalchemy.dialects import postgresql
 from sqlalchemy_utils.functions import create_database
 from sqlalchemy_utils.functions import database_exists
@@ -189,7 +188,7 @@ class GraphDatabase(SQLBase):
 
         echo = bool(int(os.getenv("THOTH_STORAGES_DEBUG_QUERIES", 0)))
         # We do not use connection pool, but directly talk to the database.
-        self._engine = create_engine(self.construct_connection_string(), echo=echo, poolclass=NullPool)
+        self._engine = create_engine(self.construct_connection_string(), echo=echo, pool_pre_ping=True)
         self._session = sessionmaker(bind=self._engine)()
 
         try:
@@ -199,10 +198,6 @@ class GraphDatabase(SQLBase):
                 )
         except DatabaseNotInitialized as exc:
             _LOGGER.warning("Database is not ready to receive or query data: %s", str(exc))
-
-    def ping(self) -> None:
-        """Check database connection with a minimal overhead."""
-        self._session.execute("SELECT 1")
 
     def initialize_schema(self):
         """Initialize schema of database."""


### PR DESCRIPTION
Use pre-ping mechanism directly offered by SQLAlchemy to check connection
health.