### PR TITLE
Issue warning instead of error for metadata keys not compliant with version 2.1 of core metadata specification.

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -4632,7 +4632,7 @@ class GraphDatabase(SQLBase):
 
                 if importlib_metadata:
                     # There can be raised PythonPackageMetadataAttributeMissing once all metadata gathered.
-                    _LOGGER.error(
+                    _LOGGER.warning(
                         "Cannot sync the whole solver result: "
                         f"No related columns for {list(importlib_metadata.keys())!r} "
                         "found in PythonPackageMetadata table, the error is not fatal"


### PR DESCRIPTION
Fixes: https://github.com/thoth-station/storages/issues/1324

Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>