### PR TITLE
Introduce new sorting types for queries

### DIFF
--- a/thoth/storages/exceptions.py
+++ b/thoth/storages/exceptions.py
@@ -82,8 +82,8 @@ class DistutilsKeyNotKnown(ThothStorageException):
     """Raised if a distutils in Python Package metadata is not known."""
 
 
-class SortTypeQueryError(ThothStorageException):
-    """Raised if a sort key used in a query is not known."""
+class SortTypeQueryUnavailable(ThothStorageException):
+    """Raised if a sort key is not available for a certain query."""
 
 
 class NoDocumentIdError(ThothStorageException):

--- a/thoth/storages/graph/enums.py
+++ b/thoth/storages/graph/enums.py
@@ -68,5 +68,6 @@ class MetadataDistutilsTypeEnum(Enum):
 class QuerySortTypeEnum(Enum):
     """Class for the requirements format."""
 
-    PACKAGE_NAME = "package_name"
-    PACKAGE_VERSION = "package_version"
+    PACKAGE_NAME = 0
+    PACKAGE_VERSION_NUMBER = 1
+    PACKAGE_RELEASE = 2


### PR DESCRIPTION
- Introduced sorting types for `package_version_number` and `package_release`

```
Test

FUNCTION: get_python_packages_all_versions

INPUTS: {'sort_by': <QuerySortTypeEnum.PACKAGE_RELEASE: 2>, 'distinct': False, 'python_version': None, 'os_version': None, 'os_name': None, 'count': 20, 'start_offset': 0, 'package_name': 'tensorflow'}

RESULTS: [{'tensorflow': [('1.11.0', 'https://pypi.org/simple'), ('1.11.0rc0', 'https://pypi.org/simple'), ('1.10.1', 'https://pypi.org/simple'), ('1.10.1', 'https://tensorflow.pypi.thoth-station.ninja/index/manylinux2010/AVX2/simple'), ('1.10.0', 'https://pypi.org/simple'), ('1.10.0rc1', 'https://pypi.org/simple'), ('1.10.0rc0', 'https://pypi.org/simple'), ('1.1.0', 'https://pypi.org/simple'), ('1.1.0', 'https://tensorflow.pypi.thoth-station.ninja/index/manylinux2010/AVX2/simple'), ('1.1.0rc2', 'https://pypi.org/simple'), ('1.1.0rc1', 'https://pypi.org/simple'), ('1.1.0rc0', 'https://pypi.org/simple'), ('1.0.1', 'https://pypi.org/simple'), ('1.0.0', 'https://pypi.org/simple'), ('1.0.0', 'https://tensorflow.pypi.thoth-station.ninja/index/manylinux2010/AVX2/simple'), ('0.12.1', 'https://pypi.org/simple'), ('0.12.1', 'https://tensorflow.pypi.thoth-station.ninja/index/manylinux2010/AVX2/simple'), ('0.12.0', 'https://pypi.org/simple'), ('0.12.0rc1', 'https://pypi.org/simple'), ('0.12.0rc0', 'https://pypi.org/simple')]}]
0.2354832530000408

Test

FUNCTION: get_python_packages_all_versions

INPUTS: {'sort_by': <QuerySortTypeEnum.PACKAGE_RELEASE: 2>, 'distinct': False, 'python_version': None, 'os_version': None, 'os_name': None, 'count': 20, 'start_offset': 0, 'package_name': None}
<QuerySortTypeEnum.PACKAGE_RELEASE: 2> is used only if package_name is provided for this query.

RESULTS: [{'abci': [('0.2.0', 'https://pypi.org/simple'), ('0.3.0', 'https://pypi.org/simple'), ('0.4.0', 'https://pypi.org/simple'), ('0.4.1', 'https://pypi.org/simple'), ('0.4.2', 'https://pypi.org/simple'), ('0.5.0', 'https://pypi.org/simple'), ('0.5.1', 'https://pypi.org/simple'), ('0.6.0', 'https://pypi.org/simple'), ('0.6.1', 'https://pypi.org/simple')]}, {'absl-py': [('0.0', 'https://pypi.org/simple'), ('0.1.0', 'https://pypi.org/simple'), ('0.1.1', 'https://pypi.org/simple'), ('0.1.10', 'https://pypi.org/simple'), ('0.1.10', 'https://tensorflow.pypi.thoth-station.ninja/index/manylinux2010/AVX2/simple'), ('0.1.11', 'https://pypi.org/simple'), ('0.1.11', 'https://tensorflow.pypi.thoth-station.ninja/index/manylinux2010/AVX2/simple'), ('0.1.12', 'https://pypi.org/simple'), ('0.1.12', 'https://tensorflow.pypi.thoth-station.ninja/index/manylinux2010/AVX2/simple'), ('0.1.13', 'https://pypi.org/simple'), ('0.1.13', 'https://tensorflow.pypi.thoth-station.ninja/index/manylinux2010/AVX2/simple')]}]
0.7047084100000234

Test

FUNCTION: get_python_packages_all_versions

INPUTS: {'sort_by': <QuerySortTypeEnum.PACKAGE_NAME: 0>, 'distinct': False, 'python_version': None, 'os_version': None, 'os_name': None, 'count': 20, 'start_offset': 0, 'package_name': 'tensorflow'}
Traceback (most recent call last):
  File "test_queries_.py", line 83, in <module>
    sort_by=QuerySortTypeEnum.PACKAGE_NAME
  File "/home/fmurdaca/work/aicoe/storages/TestQueries.py", line 106, in test_get_python_packages_all_versions
    print("\nRESULTS:", cls.graph.get_python_packages_all_versions(**inputs))
  File "/home/fmurdaca/work/aicoe/storages/thoth/storages/graph/postgres.py", line 3244, in get_python_packages_all_versions
    raise SortTypeQueryUnavailable(f"{sort_by} type not provided for this query.")
thoth.storages.exceptions.SortTypeQueryUnavailable: QuerySortTypeEnum.PACKAGE_NAME type not provided for this query.
```

Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>