### PR TITLE
Adjust Python Package Metadata query

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -3379,19 +3379,35 @@ class GraphDatabase(SQLBase):
 
     def get_classifiers_python_package_version_metadata(
         self,
-        package_metadata_id: int,
+        python_package_metadata_id: int,
     ) -> List[str]:
         """Retrieve classifiers metadata for Python package metadata."""
         with self._session_scope() as session:
             query = (
                 session.query(HasMetadataClassifier)
-                .filter(HasMetadataClassifier.python_package_metadata_id == package_metadata_id)
+                .filter(HasMetadataClassifier.python_package_metadata_id == python_package_metadata_id)
                 .join(PythonPackageMetadataClassifier)
             ).with_entities(
                 PythonPackageMetadataClassifier
             )
 
             return [c.to_dict()["classifier"] for c in query.all()]
+
+    def get_platforms_python_package_version_metadata(
+        self,
+        python_package_metadata_id: int,
+    ) -> List[str]:
+        """Retrieve platforms metadata for Python package metadata."""
+        with self._session_scope() as session:
+            query = (
+                session.query(HasMetadataPlatform)
+                .filter(HasMetadataPlatform.python_package_metadata_id == python_package_metadata_id)
+                .join(PythonPackageMetadataPlatform)
+            ).with_entities(
+                PythonPackageMetadataPlatform
+            )
+
+            return [c.to_dict()["platform"] for c in query.all()]
 
     def get_python_package_version_metadata(
         self,
@@ -3427,7 +3443,8 @@ class GraphDatabase(SQLBase):
                 raise NotFoundError(f"No record found for {package_name!r}, {package_version!r}, {index_url!r}")
 
             formatted_result = result.to_dict()
-            formatted_result["classifiers"] = self.get_classifiers_python_package_version_metadata(result.id)
+            formatted_result["classifier"] = self.get_classifiers_python_package_version_metadata(result.id)
+            formatted_result["platform"] = self.get_platforms_python_package_version_metadata(result.id)
 
             return formatted_result
 


### PR DESCRIPTION
- Added missing metadata to the output of get Python Package metadata query

Fixes: https://github.com/thoth-station/user-api/issues/680

```
Test

FUNCTION: get_python_package_version_metadata

INPUTS: {'index_url': 'https://tensorflow.pypi.thoth-station.ninja/index/manylinux2010/AVX2/simple', 'package_version': '2.0.0', 'package_name': 'tensorflow'}

RESULTS: {
'author': 'Red Hat Inc.', 
'author_email': 'smodeel@redhat.com', 
'download_url': 'https://github.com/tensorflow/tensorflow/tags', 
'home_page': 'https://www.tensorflow.org/', 
'keywords': 'tensorflow tensor machine learning', 
'license': 'Apache 2.0', 
'maintainer': None, 
'maintainer_email': None, 
'metadata_version': '2.1', 
'name': 'tensorflow', 
'summary': 'TensorFlow is an open source machine learning framework for everyone.', 
'version': '2.0.0', 
'requires_python': None, 
'description': None, 
'description_content_type': None, 
'classifiers': ['Intended Audience :: Developers', 'Topic :: Software Development :: Libraries :: Python Modules', 'Programming Language :: Python :: 2.7', 'Programming Language :: Python :: 2', 'Topic :: Software Development', 'Programming Language :: Python :: 3', 'Programming Language :: Python :: 3.4', 'Development Status :: 5 - Production/Stable', 'License :: OSI Approved :: Apache Software License', 'Programming Language :: Python :: 3.5', 'Programming Language :: Python :: 3.6', 'Topic :: Software Development :: Libraries', 'Programming Language :: Python :: 3.7', 'Intended Audience :: Science/Research', 'Intended Audience :: Education', 'Topic :: Scientific/Engineering', 'Topic :: Scientific/Engineering :: Mathematics', 'Topic :: Scientific/Engineering :: Artificial Intelligence'],
'platform': ['CentOS release 6.10 (Final)'],
'supported_platform': [], 
'requires_external': [], 
'project_url': [], 
'provides_extra': [], 
'requires_dist': ['absl-py (>=0.7.0)', 'astor (>=0.6.0)', 'gast (==0.2.2)', 'google-pasta (>=0.1.6)', 'keras-applications (>=1.0.8)', 'keras-preprocessing (>=1.0.5)', 'numpy (<2.0,>=1.16.0)', 'opt-einsum (>=2.3.2)', 'six (>=1.10.0)', 'protobuf (>=3.6.1)', 'tensorboard (<2.1.0,>=2.0.0)', 'tensorflow-estimator (<2.1.0,>=2.0.0)', 'termcolor (>=1.1.0)', 'wrapt (>=1.11.1)', 'grpcio (>=1.8.6)', 'wheel (>=0.26)', 'backports.weakref (>=1.0rc1); python_version < "3.4"', 'enum34 (>=1.1.6); python_version < "3.4"'], 
'provides_dist': [], 
'obsolete_dist': []}
0.1498656830008258
```

Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>