### PR TITLE
Do not dispose engine in destructor

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -190,8 +190,6 @@ class GraphDatabase(SQLBase):
             stats = self.stats()
             _LOGGER.info("Graph adapter statistics:\n%s", json.dumps(stats, indent=2))
 
-        super().__del__()
-
     @staticmethod
     def construct_connection_string() -> str:
         """Construct a connection string needed to connect to database."""

--- a/thoth/storages/graph/sql_base.py
+++ b/thoth/storages/graph/sql_base.py
@@ -70,8 +70,3 @@ class SQLBase:
             raise NotConnected("Cannot initialize schema: the adapter is not connected yet")
 
         self._DECLARATIVE_BASE.metadata.drop_all(self._engine)
-
-    def __del__(self) -> None:
-        """Disconnect properly on object destruction."""
-        if self.is_connected():
-            self.disconnect()


### PR DESCRIPTION
If dispose is called in destructor, it fails as some of the objects are already
freed by Python GC collector. This produced annoying warning in logs.

Fixes: #1374