### PR TITLE
Added build log analysis result observations to graph database

### DIFF
--- a/thoth/storages/graph/models.py
+++ b/thoth/storages/graph/models.py
@@ -145,6 +145,7 @@ class PythonPackageVersionEntity(Base, BaseExtension):
 
     versions = relationship("DependsOn", back_populates="entity")
     package_extract_runs = relationship("Identified", back_populates="python_package_version_entity")
+    build_log_analyzer_runs = relationship("BuildLogAnalyzerRun", back_populates="input_python_package_version_entity")
     package_analyzer_runs = relationship("PackageAnalyzerRun", back_populates="input_python_package_version_entity")
     cves = relationship("HasVulnerability", back_populates="python_package_version_entity")
     # inspection_software_stacks = relationship("PythonSoftwareStack", back_populates="python_package_version_entity")
@@ -361,13 +362,34 @@ class CVE(Base, BaseExtension):
     python_package_version_entities = relationship("HasVulnerability", back_populates="cve")
 
 
+class BuildLogAnalyzerRun(Base, BaseExtension):
+    """A class representing a single buildlogs-analyzer (build log analysis) run."""
+
+    __tablename__ = "build_log_analyzer_run"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    build_log_analyzer_name = Column(Text, nullable=True)
+    build_log_analyzer_version = Column(Text, nullable=True)
+    build_log_analysis_document_id = Column(Text, nullable=False)
+    datetime = Column(DateTime, nullable=False)
+    debug = Column(Boolean, nullable=False, default=False)
+    build_log_analyzer_error_reason = Column(Text, nullable=True)
+    duration = Column(Integer, nullable=True)
+    input_python_package_version_entity_id = Column(
+        Integer, ForeignKey("python_package_version_entity.id", ondelete="CASCADE")
+    )
+
+    input_python_package_version_entity = relationship(
+        "PythonPackageVersionEntity", back_populates="build_log_analyzer_runs"
+    )
+
+
 class PackageAnalyzerRun(Base, BaseExtension):
     """A class representing a single package-analyzer (package analysis) run."""
 
     __tablename__ = "package_analyzer_run"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-
     package_analyzer_name = Column(String(256), nullable=True)
     package_analyzer_version = Column(String(256), nullable=True)
     package_analysis_document_id = Column(String(256), nullable=False)
@@ -1419,6 +1441,7 @@ class PythonPackageMetadataDistutils(Base, BaseExtension):
 ALL_MAIN_MODELS = frozenset(
     (
         AdviserRun,
+        BuildLogAnalyzerRun,
         CVE,
         DebDependency,
         DebPackageVersion,

--- a/thoth/storages/sync.py
+++ b/thoth/storages/sync.py
@@ -34,6 +34,7 @@ from amun import has_inspection_job
 
 from .solvers import SolverResultsStore
 from .analyses import AnalysisResultsStore
+from .buildlogs_analyses import BuildLogsAnalysisResultsStore
 from .package_analyses import PackageAnalysisResultsStore
 from .advisers import AdvisersResultsStore
 from .inspections import InspectionResultsStore
@@ -194,6 +195,61 @@ def sync_analysis_documents(
                 failed += 1
         else:
             _LOGGER.info(f"Sync of analysis document with id {document_id!r} skipped - already synced")
+            skipped += 1
+
+    return processed, synced, skipped, failed
+
+
+def sync_build_log_analysis_documents(
+    document_ids: Optional[List[str]] = None,
+    force: bool = False,
+    graceful: bool = False,
+    graph: Optional[GraphDatabase] = None,
+    is_local: bool = False,
+) -> tuple:
+    """Sync build log analysis documents into graph."""
+    if is_local and not document_ids:
+        raise ValueError(
+            "Cannot sync documents from local directory without explicitly specifying a list of documents to be synced"
+        )
+
+    if not graph:
+        graph = GraphDatabase()
+        graph.connect()
+
+    if not is_local:
+        build_log_analysis_store = BuildLogsAnalysisResultsStore()
+        build_log_analysis_store.connect()
+
+    processed, synced, skipped, failed = 0, 0, 0, 0
+    for document_id in document_ids or buildlog_analysis_store.get_document_listing():
+        processed += 1
+
+        if force or not graph.build_log_analysis_document_id_exist(os.path.basename(document_id)):
+            try:
+                if is_local:
+                    _LOGGER.debug("Loading document from a local file: %r", document_id)
+                    with open(document_id, "r") as document_file:
+                        document = json.loads(document_file.read())
+                else:
+                    _LOGGER.info(
+                        "Syncing build log analysis document from %r with id %r to graph",
+                        build_log_analysis_store.ceph.host,
+                        document_id,
+                    )
+                    document = build_log_analysis_store.retrieve_document(document_id)
+                # Analysis results with no information are not required
+                if document["result"]["build_breaker"]:
+                    graph.sync_build_log_analysis_result(document)
+                    synced += 1
+            except Exception:
+                if not graceful:
+                    raise
+
+                _LOGGER.exception("Failed to sync build log analysis result with document id %r", document_id)
+                failed += 1
+        else:
+            _LOGGER.info("Sync of build log analysis document with id %r skipped - already synced", document_id)
             skipped += 1
 
     return processed, synced, skipped, failed
@@ -448,12 +504,13 @@ def sync_inspection_documents(
 
 _HANDLERS_MAPPING = {
     "adviser": sync_adviser_documents,
-    "solver": sync_solver_documents,
-    "package-extract": sync_analysis_documents,
-    "package-analyzer": sync_package_analysis_documents,
-    "provenance-checker": sync_provenance_checker_documents,
+    "build-report": sync_build_log_analysis_documents,
     "dependency-monkey": sync_dependency_monkey_documents,
     "inspection": sync_inspection_documents,
+    "package-analyzer": sync_package_analysis_documents,
+    "package-extract": sync_analysis_documents,
+    "provenance-checker": sync_provenance_checker_documents,
+    "solver": sync_solver_documents,
 }
 
 


### PR DESCRIPTION
Added build log analysis result observations to graph database
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Dependencies

Depends-On: #1510 

## This introduces a breaking change

- [ ] Yes
- [x] No

Shouldn't break any other components as it is updated a new table into the SQL database.

## This should yield a new module release

- [x] Yes
- [ ] No

This requires a schema update and module release.

## This Pull Request implements

The PR changes, sync.py, progress.py and model.py adding build logs analysis result to the database.

## Description

The result of the build breaker is stated below, based on that a table to store these results is produced.  table : build_log_analyzer_run
```
{
  "result": {
    "build_breaker": {
      "already_satisfied": null,
      "source": null,
      "target": "six",
      "version_installed": null,
      "version_specified": "==1.10.0,>=1.11.0,>=1.5,>=1.9.0"
    },
    "reason": {
      "ln": 31,
      "msg": "ERROR: ERROR: Could not find a version that matches six==1.10.0,>=1.11.0,>=1.5,>=1.9.0"
    },
    "candidates": [ ... ]
  },
  "metadata": {
    "analyzer": "thoth-build-analyzers",
    "datetime": "2020-01-15T21:53:37.829729",
    "document_id": null,
    "timestamp": 1579125217,
    "hostname": "workstation",
    "analyzer_version": "0.1.0",
    "distribution": {
      "id": "fedora",
      "version": "31",
      "version_parts": {
        "major": "31",
        "minor": "",
        "build_number": ""
      },
      "like": "",
      "codename": ""
    },
    "arguments": {
      "report": {
        "log": "/home/hnalla/thoth-station/build-analyzers/fixtures/pipenv.failed.log",
        "limit": null,
        "handler": null,
        "ceph_document_id": null,
        "report_output": "-",
        "colorize": true,
        "pretty": false
      },
      "thoth-build-analyzer": {
        
      }
    },
    "duration": 0,
    "python": {
      "major": 3,
      "minor": 6,
      "micro": 9,
      "releaselevel": "final",
      "serial": 0,
      "api_version": 1013,
      "implementation_name": "cpython"
    },
    "os_release": {
      "name": "Fedora",
      "version": "31 (Workstation Edition)",
      "id": "fedora",
      "version_id": "31",
      "platform_id": "platform:f31",
      "redhat_bugzilla_product": "Fedora",
      "redhat_bugzilla_product_version": "31",
      "redhat_support_product": "Fedora",
      "redhat_support_product_version": "31",
      "variant_id": "workstation"
    },
    "thoth_deployment_name": null
  }
}
```