### PR TITLE
Set Packages Extract flag is_external to True always

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -3886,7 +3886,7 @@ class GraphDatabase(SQLBase):
                 os_version=software_environment.os_version,
                 python_version=software_environment.python_version,
                 index_url=None,
-                sync_only_entity=document["metadata"]["arguments"]["thoth-package-extract"]["metadata"]["is_external"],
+                sync_only_entity=True,
             )
 
             Identified.get_or_create(


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies
Fixes: https://github.com/thoth-station/storages/issues/1521

## This introduces a breaking change

- [ ] Yes
- [x] No

## This should yield a new module release

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Set a flag for correct package extract results syncing.
