### PR TITLE
Fixed missing index issue

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -4029,18 +4029,10 @@ class GraphDatabase(SQLBase):
         package_version = document["result"]["build_breaker"]["version_specified"]
         package_version = self.normalize_python_package_version(package_version)
 
-        _LOGGER.info(
-            "Syncing package analysis for package %r in version %r from %r", package_name, package_version, index_url
-        )
+        _LOGGER.info("Syncing package analysis for package %r in version %r", package_name, package_version)
         with self._session_scope() as session, session.begin(subtransactions=True):
-            python_package_index = self._get_or_create_python_package_index(
-                session, index_url=index_url, only_if_enabled=False
-            )
             python_package_version_entity, _ = PythonPackageVersionEntity.get_or_create(
-                session,
-                package_name=package_name,
-                package_version=package_version,
-                python_package_index_id=python_package_index.id,
+                session, package_name=package_name, package_version=package_version
             )
             build_log_analyzer_run, _ = BuildLogAnalyzerRun.get_or_create(
                 session,


### PR DESCRIPTION
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: #1555 

## This introduces a breaking change

- [x] Yes
- [ ] No

## This should yield a new module release

- [x] Yes
- [ ] No

This a fix to a breaking change.

## This Pull Request implements

https://github.com/thoth-station/storages/blob/2854f1b8444b873f7050210bccfa758a2d906d3d/thoth/storages/graph/models.py#L144

As the index value is not required.

## Description

only package_name and package_version is provided by the build_analyzers, it could be passed to  PythonPackageVersionEntity without the index.