### PR TITLE
No need to query for package extract run - software environment can be directly used

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -4707,10 +4707,9 @@ class GraphDatabase(SQLBase):
         """Get symbols associated with a given image."""
         with self._session_scope() as session:
             query = (
-                session.query(PackageExtractRun)
-                .filter(PackageExtractRun.os_id == os_name)
-                .filter(PackageExtractRun.os_version_id == self.normalize_os_version(os_name, os_version))
-                .join(SoftwareEnvironment)
+                session.query(SoftwareEnvironment)
+                .filter(SoftwareEnvironment.os_name == os_name)
+                .filter(SoftwareEnvironment.os_version == self.normalize_os_version(os_name, os_version))
                 .filter(SoftwareEnvironment.cuda_version == cuda_version)
                 .filter(SoftwareEnvironment.python_version == python_version)
                 .join(HasSymbol)


### PR DESCRIPTION
## This introduces a breaking change

- [ ] Yes
- [x] No

## This should yield a new module release

- [ ] Yes
- [x] No