### PR TITLE
Add check in sync when report is not provided by Adviser

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -4548,6 +4548,12 @@ class GraphDatabase(SQLBase):
             )
 
             # Output stacks - advised stacks
+            if not document["result"].get("report", {}):
+                _LOGGER.warning(
+                    "No report found in %r", adviser_document_id
+                )
+                return
+
             for idx, product in enumerate(document["result"].get("report", {}).get("products", [])):
                 print(idx)
                 performance_score = None


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## This introduces a breaking change

- [ ] Yes
- [x] No

## This should yield a new module release

- [x] Yes
- [ ] No

## This Pull Request implements

Add check in adviser sync when report is not provided by Adviser document

