### PR TITLE
Move import to local use

### DIFF
--- a/thoth/storages/sync.py
+++ b/thoth/storages/sync.py
@@ -26,7 +26,6 @@ from typing import List
 from typing import Optional
 
 from amun import get_inspection_build_log
-from amun import get_inspection_job_log
 from amun import get_inspection_specification
 from amun import get_inspection_status
 from amun import is_inspection_finished
@@ -429,6 +428,8 @@ def sync_inspection_documents(
     is_local: bool = False,
 ) -> tuple:
     """Sync observations made on Amun into graph database."""
+    from amun import get_inspection_job_log
+
     if is_local:
         raise NotImplementedError("Cannot sync inspection documents from a local file")
 


### PR DESCRIPTION
## Related Issues and Dependencies

With argo workflows, we don't have this function anymore.

## This introduces a breaking change

- [ ] Yes
- [x] No

## This should yield a new module release

- [ ] Yes
- [x] No

