### PR TITLE
Remove constraint on deployment name to allow for retrieval of inspections

### DIFF
--- a/thoth/storages/result_base.py
+++ b/thoth/storages/result_base.py
@@ -55,10 +55,16 @@ class ResultStorageBase(StorageBase):
             self.RESULT_TYPE
         ), "Make sure RESULT_TYPE in derived classes to distinguish between adapter type instances is non-empty."
 
-        self.deployment_name = deployment_name or os.environ["THOTH_DEPLOYMENT_NAME"]
-        self.prefix = "{}/{}/{}".format(
-            prefix or os.environ["THOTH_CEPH_BUCKET_PREFIX"], self.deployment_name, self.RESULT_TYPE
-        )
+        self.deployment_name = deployment_name or os.getenv("THOTH_DEPLOYMENT_NAME")
+
+        if self.deployment_name:
+            self.prefix = "{}/{}/{}".format(
+                prefix or os.environ["THOTH_CEPH_BUCKET_PREFIX"], self.deployment_name, self.RESULT_TYPE
+            )
+        else:
+            self.prefix = "{}/{}".format(
+                prefix or os.environ["THOTH_CEPH_BUCKET_PREFIX"], self.RESULT_TYPE
+            )
         self.ceph = CephStore(
             self.prefix, host=host, key_id=key_id, secret_key=secret_key, bucket=bucket, region=region
         )


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## This introduces a breaking change

- [ ] Yes
- [x] No

## This should yield a new module release

- [x] Yes
- [ ] No

## This Pull Request implements

Remove the constraint on THOTH_DEPLOYMENT_NAME env variable. We were storing documents in 
```
self.prefix = "{}/{}/{}".format(
                prefix or os.environ["THOTH_CEPH_BUCKET_PREFIX"], self.deployment_name, self.RESULT_TYPE
            )
```
e.g. `thoth/data/thoth-psi-stage/inspections`
with `prefix=thoth/data`, `deployment_name=thoth-psi-stage`

but with argo workflows we store results in:
```
            self.prefix = "{}/{}".format(
                prefix or os.environ["THOTH_CEPH_BUCKET_PREFIX"], self.RESULT_TYPE
            )
```

e.g. `argo/inspections`
## Description

Relax constraint on environment variable and add an if statement to maintain the previous compatibility for bucket on Ceph