### PR TITLE
Reduce number of queries for environment markers by caching results

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -174,6 +174,8 @@ _GET_PYTHON_CVE_RECORDS_ALL_CACHE_SIZE = int(os.getenv("THOTH_STORAGE_GET_PYTHON
 _GET_PYTHON_PACKAGE_REQUIRED_SYMBOLS_CACHE_SIZE = int(
     os.getenv("THOTH_STORAGE_GET_PYTHON_PACKAGE_REQUIRED_SYMBOLS_CACHE_SIZE", 4096)
 )
+_GET_PYTHON_ENVIRONMENT_MARKER_CACHE_SIZE = int(os.getenv("THOTH_GET_PYTHON_ENVIRONMENT_MARKER_CACHE_SIZE", 4096))
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -2298,6 +2300,7 @@ class GraphDatabase(SQLBase):
 
         return result
 
+    @lru_cache(maxsize=_GET_PYTHON_ENVIRONMENT_MARKER_CACHE_SIZE)
     def get_python_environment_marker(
         self,
         package_name: str,


### PR DESCRIPTION
## Related Issues and Dependencies

With the fix in https://github.com/thoth-station/adviser/pull/856 we put more pressure on the database that can be easily freed using this fix.

## This introduces a breaking change

- [ ] Yes
- [x] No

## This should yield a new module release

- [x] Yes
- [ ] No