### PR TITLE
Add import or classes cannot be accessed

### DIFF
--- a/thoth/storages/__init__.py
+++ b/thoth/storages/__init__.py
@@ -34,6 +34,8 @@ from .package_analyses import PackageAnalysisResultsStore
 from .provenance import ProvenanceResultsStore
 from .provenance_cache import ProvenanceCacheStore
 from .result_schema import RESULT_SCHEMA
+from .si_bandit import SIBanditResultsStore
+from .si_cloc import SIClocResultsStore
 from .solvers import SolverResultsStore
 from .sync import sync_adviser_documents
 from .sync import sync_analysis_documents


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/storages/issues/1828

## This introduces a breaking change

- [ ] Yes
- [x] No

## This should yield a new module release

- [x] Yes
- [ ] No

## This Pull Request implements

Add imports