### PR TITLE
Move imports of amun to local scope

### DIFF
--- a/thoth/storages/sync.py
+++ b/thoth/storages/sync.py
@@ -25,12 +25,6 @@ from typing import Tuple
 from typing import List
 from typing import Optional
 
-from amun import get_inspection_build_log
-from amun import get_inspection_specification
-from amun import get_inspection_status
-from amun import is_inspection_finished
-from amun import has_inspection_job
-
 from .solvers import SolverResultsStore
 from .revsolvers import RevSolverResultsStore
 from .analyses import AnalysisResultsStore
@@ -478,7 +472,12 @@ def sync_inspection_documents(
     is_local: bool = False,
 ) -> tuple:
     """Sync observations made on Amun into graph database."""
+    from amun import get_inspection_build_log
     from amun import get_inspection_job_log
+    from amun import get_inspection_specification
+    from amun import get_inspection_status
+    from amun import has_inspection_job
+    from amun import is_inspection_finished
 
     if is_local:
         raise NotImplementedError("Cannot sync inspection documents from a local file")


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/amun-api/pull/403
https://github.com/thoth-station/amun-api/pull/431


## This introduces a breaking change

- [ ] Yes
- [x] No

## This should yield a new module release

- [ ] Yes
- [x] No

## This Pull Request implements

As Amun API was redesigned, we will no longer query API endpoints to obtain results. We will rather use data placed on Ceph. This will unify graph-sync handling with other jobs. To support this idea, amun-client will be removed from dependencies. Until that point, let's move amun-client imports to local scope as newly generated amun-client will introduce breaking changes.