### PR TITLE
Remove methods causing issues during initialization and creation of schema when database has different name than postgres

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -298,7 +298,7 @@ class GraphDatabase(SQLBase):
             return
 
         try:
-            if not self.is_schema_up2date(is_connected):
+            if not self.is_schema_up2date():
                 _LOGGER.warning(
                     "Database schema is not up to date, you might encounter issues when manipulating with the database"
                 )

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -268,12 +268,9 @@ class GraphDatabase(SQLBase):
             raise AlreadyConnected("Cannot connect, the adapter is already connected")
 
         echo = bool(int(os.getenv("THOTH_STORAGES_DEBUG_QUERIES", 0)))
-        #TODO: Remove once https://github.com/kvesteri/sqlalchemy-utils/pull/372 is merged and new release of sqlalchemy_utils is issued
-        is_successfully_started = False
         try:
             self._engine = create_engine(self.construct_connection_string(), echo=echo)
             self._sessionmaker = sessionmaker(bind=self._engine)
-            is_successfully_started = True
         except Exception as engine_exc:
             _LOGGER.warning("Failed to create engine: %s", str(engine_exc))
             # Drop engine and session in case of any connection issues so is_connected behaves correctly.

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -266,12 +266,12 @@ class GraphDatabase(SQLBase):
             raise AlreadyConnected("Cannot connect, the adapter is already connected")
 
         echo = bool(int(os.getenv("THOTH_STORAGES_DEBUG_QUERIES", 0)))
-        #TODO: Remove once https://github.com/kvesteri/sqlalchemy-utils/pull/372 is merged and new release of sqlalchemy_utils is released
+        #TODO: Remove once https://github.com/kvesteri/sqlalchemy-utils/pull/372 is merged and new release of sqlalchemy_utils is issued
         is_successfully_started = False
         try:
             self._engine = create_engine(self.construct_connection_string(), echo=echo)
             self._sessionmaker = sessionmaker(bind=self._engine)
-            self._is_successfully_started = True
+            is_successfully_started = True
         except Exception as engine_exc:
             _LOGGER.warning("Failed to create engine: %s", str(engine_exc))
             # Drop engine and session in case of any connection issues so is_connected behaves correctly.
@@ -285,7 +285,7 @@ class GraphDatabase(SQLBase):
             self._sessionmaker = None
             raise
 
-        if not self._is_successfully_started:
+        if not is_successfully_started:
             _LOGGER.warning("The database has not been created yet, no check for schema version is performed")
             return
 

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -272,10 +272,8 @@ class GraphDatabase(SQLBase):
         try:
             self._engine = create_engine(self.construct_connection_string(), echo=echo)
             self._sessionmaker = sessionmaker(bind=self._engine)
-            print("Engine started successfully")
             self._is_successfully_started = True
         except Exception as engine_exc:
-            print("Engine did not started successfully", str(engine_exc))
             _LOGGER.warning("Failed to create engine: %s", str(engine_exc))
             # Drop engine and session in case of any connection issues so is_connected behaves correctly.
             if self._engine:
@@ -287,11 +285,6 @@ class GraphDatabase(SQLBase):
             self._engine = None
             self._sessionmaker = None
             raise
-
-        print("Engine URL", str(self._engine.url))
-        print("Engine URL database", self._engine.url.database)
-        print("Engine URL drivername:", self._engine.url.drivername)
-        print("Engine Dialect name", self._engine.dialect.name)
 
         if not self._is_successfully_started:
             _LOGGER.warning("The database has not been created yet, no check for schema version is performed")
@@ -313,10 +306,6 @@ class GraphDatabase(SQLBase):
 
         if not self.is_connected():
             raise NotConnected("Cannot initialize schema: the adapter is not connected yet")
-
-        if not self._is_successfully_started:
-            _LOGGER.warning("The database has not been created yet, no check for schema version is performed")
-            return
 
         alembic_cfg = config.Config(os.path.join(os.path.dirname(thoth.storages.__file__), "data", "alembic.ini"))
         alembic_cfg.attributes["configure_logger"] = False

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -284,7 +284,10 @@ class GraphDatabase(SQLBase):
             self._sessionmaker = None
             raise
 
-        _LOGGER.warning("Engine URL: %s", str(self._engine.url))
+        print(str(self._engine.url))
+        print(self._engine.url.database)
+        print("URL drivername:", self._engine.url.drivername)
+
         if not database_exists(self._engine.url):
             _LOGGER.warning("The database has not been created yet, no check for schema version is performed")
             return

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -48,8 +48,6 @@ from sqlalchemy.orm import Query
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.session import Session
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy_utils.functions import create_database
-from sqlalchemy_utils.functions import database_exists
 from thoth.python import PackageVersion
 from thoth.python import Pipfile
 from thoth.python import PipfileLock
@@ -268,6 +266,7 @@ class GraphDatabase(SQLBase):
             raise AlreadyConnected("Cannot connect, the adapter is already connected")
 
         echo = bool(int(os.getenv("THOTH_STORAGES_DEBUG_QUERIES", 0)))
+        #TODO: Remove once https://github.com/kvesteri/sqlalchemy-utils/pull/372 is merged and new release of sqlalchemy_utils is released
         is_successfully_started = False
         try:
             self._engine = create_engine(self.construct_connection_string(), echo=echo)

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -271,7 +271,8 @@ class GraphDatabase(SQLBase):
         try:
             self._engine = create_engine(self.construct_connection_string(), echo=echo)
             self._sessionmaker = sessionmaker(bind=self._engine)
-        except Exception:
+        except Exception as engine_exc:
+            _LOGGER.warning("Failed to create engine: %s", str(engine_exc))
             # Drop engine and session in case of any connection issues so is_connected behaves correctly.
             if self._engine:
                 try:
@@ -283,6 +284,7 @@ class GraphDatabase(SQLBase):
             self._sessionmaker = None
             raise
 
+        _LOGGER.warning("Engine URL: %s", str(self._engine.url))
         if not database_exists(self._engine.url):
             _LOGGER.warning("The database has not been created yet, no check for schema version is performed")
             return

--- a/thoth/storages/graph/postgres_utils.py
+++ b/thoth/storages/graph/postgres_utils.py
@@ -49,11 +49,10 @@ from sqlalchemy.exc import OperationalError, ProgrammingError
 
 _LOGGER = logging.getLogger(__name__)
 
+
 def database_exists(url):
     """Check if a database exists.
-
     :param url: A SQLAlchemy engine URL.
-
     Performs backend-specific testing to quickly determine if a database
     exists on the server. ::
         database_exists('postgres://postgres@localhost/name')  #=> False
@@ -89,11 +88,9 @@ def database_exists(url):
 
 def create_database(url, encoding="utf8", template=None):
     """Issue the appropriate CREATE DATABASE statement.
-
     :param url: A SQLAlchemy engine URL.
     :param encoding: The encoding to create the database as.
     :param template:
-
         The name of the template from which to create the new database. At the
         moment only supported by PostgreSQL driver.
     To create a database, you can pass a simple URL that would have

--- a/thoth/storages/graph/postgres_utils.py
+++ b/thoth/storages/graph/postgres_utils.py
@@ -40,6 +40,7 @@
 
 """Utils for postgresql database."""
 
+import os
 import logging
 from copy import copy
 

--- a/thoth/storages/graph/postgres_utils.py
+++ b/thoth/storages/graph/postgres_utils.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+# Methods from SQLAlchemy utils modified.
+# TODO: remove once https://github.com/kvesteri/sqlalchemy-utils/pull/372 is merged
+#
+###################################################################
+#  SQLAlchemy utils methods
+# Copyright (c) 2012, Konsta Vesterinen
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# * The names of the contributors may not be used to endorse or promote products
+# derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#  See https://github.com/kvesteri/sqlalchemy-utils/blob/master/LICENSE.
+####################################################################
+#
+# Additional changes for project Thoth by Thoth team.
+#
+
+"""Utils for postgresql database."""
+
+import logging
+from copy import copy
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine.url import make_url
+from sqlalchemy.exc import OperationalError, ProgrammingError
+
+_LOGGER = logging.getLogger(__name__)
+
+def database_exists(url):
+    """Check if a database exists.
+
+    :param url: A SQLAlchemy engine URL.
+
+    Performs backend-specific testing to quickly determine if a database
+    exists on the server. ::
+        database_exists('postgres://postgres@localhost/name')  #=> False
+        create_database('postgres://postgres@localhost/name')
+        database_exists('postgres://postgres@localhost/name')  #=> True
+    Supports checking against a constructed URL as well. ::
+        engine = create_engine('postgres://postgres@localhost/name')
+        database_exists(engine.url)  #=> False
+        create_database(engine.url)
+        database_exists(engine.url)  #=> True
+
+    Modified version from sqlalchemy_utils to take care of one issue.
+    """
+
+    def get_scalar_result(engine, sql):
+        result_proxy = engine.execute(sql)
+        result = result_proxy.scalar()
+        result_proxy.close()
+        engine.dispose()
+        return result
+
+    url = copy(make_url(url))
+    database, url.database = url.database, None
+    engine = create_engine(url)
+
+    if engine.dialect.name == "postgresql":
+        text = "SELECT 1 FROM pg_database WHERE datname='%s'" % database
+        return bool(get_scalar_result(engine, text))
+
+    else:
+        _LOGGER.exception("This implementation is valid only for postgresql dialects")
+
+
+def create_database(url, encoding="utf8", template=None):
+    """Issue the appropriate CREATE DATABASE statement.
+
+    :param url: A SQLAlchemy engine URL.
+    :param encoding: The encoding to create the database as.
+    :param template:
+
+        The name of the template from which to create the new database. At the
+        moment only supported by PostgreSQL driver.
+    To create a database, you can pass a simple URL that would have
+    been passed to ``create_engine``. ::
+        create_database('postgres://postgres@localhost/name')
+    You may also pass the url from an existing engine. ::
+        create_database(engine.url)
+    Has full support for mysql, postgres, and sqlite. In theory,
+    other database engines should be supported.
+
+    Modified version from sqlalchemy_utils to take care of one issue.
+    """
+
+    url = copy(make_url(url))
+
+    database, url.database = url.database, None
+
+    engine = create_engine(url)
+    result_proxy = None
+
+    if engine.dialect.name == "postgresql":
+        if engine.driver == "psycopg2":
+            from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+            engine.raw_connection().set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+
+        if not template:
+            template = "template1"
+
+        text = "CREATE DATABASE {0} ENCODING '{1}' TEMPLATE {2}".format(
+            quote(engine, database), encoding, quote(engine, template)
+        )
+        result_proxy = engine.execute(text)
+
+    else:
+        _LOGGER.exception("This implementation is valid only for postgresql dialects")
+
+    if result_proxy is not None:
+        result_proxy.close()
+    engine.dispose()

--- a/thoth/storages/graph/postgres_utils.py
+++ b/thoth/storages/graph/postgres_utils.py
@@ -75,7 +75,7 @@ def database_exists(url):
         return result
 
     url = copy(make_url(url))
-    database, url.database = url.database, None
+    database, url.database = url.database, os.getenv('KNOWLEDGE_GRAPH_DATABASE')
     engine = create_engine(url)
 
     if engine.dialect.name == "postgresql":
@@ -106,8 +106,7 @@ def create_database(url, encoding="utf8", template=None):
 
     url = copy(make_url(url))
 
-    database, url.database = url.database, None
-
+    database, url.database = url.database, os.getenv('KNOWLEDGE_GRAPH_DATABASE')
     engine = create_engine(url)
     result_proxy = None
 


### PR DESCRIPTION
## Related Issues and Dependencies

Due to issue in `sqlalchmey_utils` which use default postgres database name: https://github.com/kvesteri/sqlalchemy-utils/pull/372

Fixes: https://github.com/thoth-station/thoth-application/issues/41

## This introduces a breaking change

- [ ] Yes
- [x] No

## This should yield a new module release

- [x] Yes
- [ ] No

## This Pull Request implements

Adapt methods that were causing issue when the name of the database is not postgres from sqlalchemy utils.