### PR TITLE
query.all returns type List[result] not List[str]

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -3062,7 +3062,7 @@ class GraphDatabase(SQLBase):
         """Retrieve names of Python package entities in the Thoth's knowledge base."""
         with self._session_scope() as session:
             query = session.query(PythonPackageVersionEntity.package_name)
-            return query.distinct().all()
+            return [i[0] for i in query.distinct().all()]
 
     def get_python_package_version_names_all(
         self, *, os_name: str = None, os_version: str = None, python_version: str = None, distinct: bool = False


### PR DESCRIPTION
## Related Issues and Dependencies
https://github.com/thoth-station/package-releases-job/issues/440

`query.all()` return type is `List[result]` not `List[str]`.  `result` can be treated as a `tuple`. So because `query.all()` returns:
```
[("foo",), ("bar",), ("baz",)]
```
for example. We can use list comprehension to turn this into ["foo", "bar", "baz"] to match the type hint return type.  This function is only used in package-releases-job rn so this change will not cause any breakages.  It will fix the bug stated above.