### PR TITLE
Adjust SI queries

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -4335,8 +4335,8 @@ class GraphDatabase(SQLBase):
 
     def _check_package_solved(self, session: Session, package_name: str, package_version: str,
                               package_index: str) -> Tuple:
-        """Check if the package has been solved before syncing it to the database."""
-        # Check all packages solved
+        """Check if the package has been solved before syncing SI analysis to the database."""
+        # Check if a package have been solved by any of the solver
         python_package_version = (
             session.query(PythonPackageVersion)
             .join(PythonPackageIndex)

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -1611,8 +1611,14 @@ class GraphDatabase(SQLBase):
         self,
         *,
         distinct: bool = False,
-    ) -> int:
-        """Get SI analyzed Python package versions in Thoth Database."""
+    ) -> List[Tuple[str, str, str]]:
+        """Get SI analyzed Python package versions in Thoth Database.
+        Examples:
+        >>> from thoth.storages import GraphDatabase
+        >>> graph = GraphDatabase()
+        >>> graph.get_si_analyzed_python_package_versions_all()
+        [('fbprophet', '0.4', 'https://pypi.org/simple')]
+        """
         with self._session_scope() as session:
             query = self._construct_si_analyzed_python_package_versions_query(
                 session
@@ -1679,7 +1685,7 @@ class GraphDatabase(SQLBase):
         count: Optional[int] = DEFAULT_COUNT,
         distinct: bool = True,
         randomize: bool = True,
-    ) -> List[Tuple[str, str]]:
+    ) -> List[Tuple[str, str, str]]:
         """Retrieve solved Python package versions in Thoth Database, that are not anaylyzed by SI. 
         Examples:
         >>> from thoth.storages import GraphDatabase
@@ -4331,7 +4337,7 @@ class GraphDatabase(SQLBase):
                               package_index: str) -> Tuple:
         """Check if the package has been solved before syncing it to the database."""
         # Check all packages solved
-        python_package_versions = (
+        python_package_version = (
             session.query(PythonPackageVersion)
             .join(PythonPackageIndex)
             .filter(PythonPackageVersion.package_name == package_name)

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -1672,7 +1672,7 @@ class GraphDatabase(SQLBase):
             query = query.filter(PythonPackageIndex.url == index_url)
 
         # We find all rows that are same in PythonPackageVersion and SIAggregated table.
-        conditions = [PythonPackageVersion.id == SIAggregated.python_package_version_id]
+        conditions = [PythonPackageVersion.entity_id == SIAggregated.python_package_version_entity_id]
 
         # Finally filter these out.
         query = query.filter(~exists().where(and_(*conditions)))


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/storages/issues/2007
Related-To: https://github.com/thoth-station/adviser/issues/1178
Related-To: https://github.com/thoth-station/thoth-application/issues/423

## This introduces a breaking change

- [ ] Yes
- [x] No

## This should yield a new module release

- [x] Yes
- [ ] No

It affects:

- [ ] adviser
- [ ] investigator
- [ ] graph-refresh-job
- [ ] metrics-exporter

that requires new releases after Thoth storages to have SI feature ready.

## This Pull Request implements

- Adjust queries due to change in SI schema.
- Introduce query to retrieve packages that has SI information

```
SI analyzed query count: 2
SI analyzed query all: [('fbprophet', '0.4', 'https://pypi.org/simple'), ('rsa', '4.0', 'https://pypi.org/simple')]
SI unanalyzed query count: 36735
Python packages releases 36737
```