### PR TITLE
Adjust query for new flag is_downloadable

### DIFF
--- a/thoth/storages/graph/models.py
+++ b/thoth/storages/graph/models.py
@@ -69,7 +69,7 @@ class PythonPackageVersion(Base, BaseExtension):
     )
     is_missing = Column(Boolean, nullable=False, default=False)
     is_downloadable = Column(Boolean, nullable=False, default=True)
-    
+
     # Relations
     dependencies = relationship("DependsOn", back_populates="version")
     solvers = relationship("Solved", back_populates="version")

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -1686,6 +1686,7 @@ class GraphDatabase(SQLBase):
         count: Optional[int] = DEFAULT_COUNT,
         distinct: bool = True,
         randomize: bool = True,
+        is_downloadable: bool = True,
     ) -> List[Tuple[str, str, str]]:
         """Retrieve solved Python package versions in Thoth Database, that are not anaylyzed by SI. 
         Examples:
@@ -1695,7 +1696,10 @@ class GraphDatabase(SQLBase):
         [('crossbar', '0.10.0', 'https://pypi.org/simple'), ('tensorflow', '1.11.0', 'https://pypi.org/simple')]
         """
         with self._session_scope() as session:
-            query = self._construct_si_unanalyzed_python_package_versions_query(session)
+            query = self._construct_si_unanalyzed_python_package_versions_query(
+                session,
+                is_downloadable=is_downloadable
+            )
 
             query = query.join(PythonPackageIndex).with_entities(
                 PythonPackageVersion.package_name,
@@ -1718,69 +1722,13 @@ class GraphDatabase(SQLBase):
         index_url: Optional[str] = None,
         *,
         distinct: bool = False,
+        is_downloadable: bool = True,
     ) -> int:
         """Get SI unanalyzed Python package versions number in Thoth Database."""
         with self._session_scope() as session:
-            query = self._construct_si_unanalyzed_python_package_versions_query(session)
-
-            query = query.join(PythonPackageIndex).with_entities(
-                PythonPackageVersion.package_name,
-                PythonPackageVersion.package_version,
-                PythonPackageIndex.url,
-            )
-
-            if distinct:
-                query = query.distinct()
-
-            return query.count()
-
-    def get_si_unanalyzed_not_downloadable_python_package_versions_all(
-        self,
-        start_offset: int = 0,
-        count: Optional[int] = DEFAULT_COUNT,
-        distinct: bool = True,
-        randomize: bool = True,
-    ) -> List[Tuple[str, str, str]]:
-        """Retrieve solved Python package versions in Thoth Database, that are not anaylyzed by SI and not downloadable. 
-        Examples:
-        >>> from thoth.storages import GraphDatabase
-        >>> graph = GraphDatabase()
-        >>> graph.get_si_unanalyzed_not_downloadable_python_package_versions_all()
-        [('crossbar', '0.10.0', 'https://pypi.org/simple'), ('tensorflow', '1.11.0', 'https://pypi.org/simple')]
-        """
-        with self._session_scope() as session:
             query = self._construct_si_unanalyzed_python_package_versions_query(
                 session,
-                is_downloadable=False
-            )
-
-            query = query.join(PythonPackageIndex).with_entities(
-                PythonPackageVersion.package_name,
-                PythonPackageVersion.package_version,
-                PythonPackageIndex.url,
-            )
-
-            if randomize:
-                query = query.order_by(func.random())
-
-            query = query.offset(start_offset).limit(count)
-
-            if distinct:
-                query = query.distinct()
-
-            return query.all()
-
-    def get_si_unanalyzed_not_downloadable_python_package_versions_count_all(
-        self,
-        index_url: Optional[str] = None,
-        *,
-        distinct: bool = False,
-    ) -> int:
-        """Get SI unanalyzed not downloadable Python package versions number in Thoth Database."""
-        with self._session_scope() as session:
-            query = self._construct_si_unanalyzed_python_package_versions_query(
-                session,
-                is_downloadable=False
+                is_downloadable=is_downloadable
             )
 
             query = query.join(PythonPackageIndex).with_entities(

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -1658,7 +1658,7 @@ class GraphDatabase(SQLBase):
             return query.count()
 
     def _construct_si_unanalyzed_python_package_versions_query(
-        self, session: Session, index_url: Optional[str] = None
+        self, session: Session, index_url: Optional[str] = None, is_downloadable: bool = True
     ) -> Query:
         """Construct query for packages analyzed by solver, but unanalyzed by SI."""
         index_url = GraphDatabase.normalize_python_index_url(index_url)
@@ -1666,6 +1666,7 @@ class GraphDatabase(SQLBase):
             PythonPackageVersion.package_version.isnot(None),
             PythonPackageIndex.url.isnot(None),
             PythonPackageIndex.enabled.is_(True),
+            PythonPackageVersion.is_downloadable.is_(is_downloadable),
         )
 
         if index_url is not None:
@@ -1721,6 +1722,66 @@ class GraphDatabase(SQLBase):
         """Get SI unanalyzed Python package versions number in Thoth Database."""
         with self._session_scope() as session:
             query = self._construct_si_unanalyzed_python_package_versions_query(session)
+
+            query = query.join(PythonPackageIndex).with_entities(
+                PythonPackageVersion.package_name,
+                PythonPackageVersion.package_version,
+                PythonPackageIndex.url,
+            )
+
+            if distinct:
+                query = query.distinct()
+
+            return query.count()
+
+    def get_si_unanalyzed_not_downloadable_python_package_versions_all(
+        self,
+        start_offset: int = 0,
+        count: Optional[int] = DEFAULT_COUNT,
+        distinct: bool = True,
+        randomize: bool = True,
+    ) -> List[Tuple[str, str, str]]:
+        """Retrieve solved Python package versions in Thoth Database, that are not anaylyzed by SI and not downloadable. 
+        Examples:
+        >>> from thoth.storages import GraphDatabase
+        >>> graph = GraphDatabase()
+        >>> graph.get_si_unanalyzed_not_downloadable_python_package_versions_all()
+        [('crossbar', '0.10.0', 'https://pypi.org/simple'), ('tensorflow', '1.11.0', 'https://pypi.org/simple')]
+        """
+        with self._session_scope() as session:
+            query = self._construct_si_unanalyzed_python_package_versions_query(
+                session,
+                is_downloadable=False
+            )
+
+            query = query.join(PythonPackageIndex).with_entities(
+                PythonPackageVersion.package_name,
+                PythonPackageVersion.package_version,
+                PythonPackageIndex.url,
+            )
+
+            if randomize:
+                query = query.order_by(func.random())
+
+            query = query.offset(start_offset).limit(count)
+
+            if distinct:
+                query = query.distinct()
+
+            return query.all()
+
+    def get_si_unanalyzed_not_downloadable_python_package_versions_count_all(
+        self,
+        index_url: Optional[str] = None,
+        *,
+        distinct: bool = False,
+    ) -> int:
+        """Get SI unanalyzed not downloadable Python package versions number in Thoth Database."""
+        with self._session_scope() as session:
+            query = self._construct_si_unanalyzed_python_package_versions_query(
+                session,
+                is_downloadable=False
+            )
 
             query = query.join(PythonPackageIndex).with_entities(
                 PythonPackageVersion.package_name,


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Related-To: https://github.com/thoth-station/thoth-application/issues/507

## This introduces a breaking change

- [ ] Yes
- [x] No

## This should yield a new module release

- [x] Yes
- [ ] No

## This Pull Request implements

Adjust queries for graph-refresh-job to retrieve packages to analyze for SI

## Description

Initially:
```
SI analyzed 525
SI unanalyzed 8231
Python packages releases 8756
```

After setting one package to be not downloadable

```
Modified is_downloadable for one package!
SI analyzed 525
SI unanalyzed 8230
Python packages releases 8756
SI unanalyzed not downloadable 1
```
