### PR TITLE
Install thoth-ssdeep requirement for thoth-storages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ sqlalchemy
 psycopg2-binary
 sqlalchemy-utils
 alembic
+thoth-ssdeep


### PR DESCRIPTION
## Related Issues and Dependencies

Related-To: https://github.com/thoth-station/adviser/pull/1572
#2046 

## This should yield a new module release

- [x] Yes
- [ ] No

## Description

Install thoth-ssdeep requirement for thoth-storages
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
