### PR TITLE
Add get active installations method

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -3476,7 +3476,14 @@ class GraphDatabase(SQLBase):
             return False
 
     def get_active_kebechet_github_installations_repos(self) -> Dict[str, List[str]]:
-        """Get all active repositories names with active Kebechet installation."""
+        """Get all active repositories names with active Kebechet installation.
+        
+         Examples:
+        >>> from thoth.storages import GraphDatabase
+        >>> graph = GraphDatabase()
+        >>> graph.get_active_kebechet_github_installations_repos()
+        ['repository_foo_fullname', 'repository_bar_fullname', ...]
+        """
         with self._session_scope() as session:
             active_installations = (
                 session.query(KebechetGithubAppInstallations)
@@ -3484,7 +3491,7 @@ class GraphDatabase(SQLBase):
                 .all()
             )
 
-            return { i.slug:self.get_kebechet_github_installations_active_managers(slug=i.slug) for i in active_installations }
+            return [ i.slug for i in active_installations ]
 
     def get_kebechet_github_installations_count_per_is_active(self) -> int:
         """Return the count of active repos with Kebechet installation."""

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -3475,12 +3475,13 @@ class GraphDatabase(SQLBase):
                 return True
             return False
 
-    def get_kebechet_github_installations_active(self) -> List[str]:
-        """Return all of the repositories wiht the active Kebechet installation."""
+    def get_kebechet_github_installations_per_is_active(self) -> List[str]:
+        """Get all active repositories names with active Kebechet installation."""
         with self._session_scope() as session:
             active_managers = (
                 session.query(KebechetGithubAppInstallations)
                 .filter(KebechetGithubAppInstallations.is_active.is_(True))
+                .all()
             )
             return [m.repo_name for m in active_managers]
 

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -3475,6 +3475,15 @@ class GraphDatabase(SQLBase):
                 return True
             return False
 
+    def get_kebechet_github_installations_active(self) -> List[str]:
+        """Return all of the repositories wiht the active Kebechet installation."""
+        with self._session_scope() as session:
+            active_managers = (
+                session.query(KebechetGithubAppInstallations)
+                .filter(KebechetGithubAppInstallations.is_active.is_(True))
+            )
+            return [m.repo_name for m in active_managers]
+
     def get_kebechet_github_installations_count_per_is_active(self) -> int:
         """Return the count of active repos with Kebechet installation."""
         with self._session_scope() as session:

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -3475,15 +3475,16 @@ class GraphDatabase(SQLBase):
                 return True
             return False
 
-    def get_kebechet_github_installations_per_is_active(self) -> List[str]:
+    def get_kebechet_github_installations_per_is_active(self) -> Dict[str, List[str]]:
         """Get all active repositories names with active Kebechet installation."""
         with self._session_scope() as session:
-            active_managers = (
+            active_installations = (
                 session.query(KebechetGithubAppInstallations)
                 .filter(KebechetGithubAppInstallations.is_active.is_(True))
                 .all()
             )
-            return [m.repo_name for m in active_managers]
+
+            return { i.slug:self.get_kebechet_github_installations_active_managers(slug=i.slug) for i in active_installations }
 
     def get_kebechet_github_installations_count_per_is_active(self) -> int:
         """Return the count of active repos with Kebechet installation."""

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -3475,7 +3475,7 @@ class GraphDatabase(SQLBase):
                 return True
             return False
 
-    def get_kebechet_github_installations_per_is_active(self) -> Dict[str, List[str]]:
+    def get_active_kebechet_github_installations_repos(self) -> Dict[str, List[str]]:
         """Get all active repositories names with active Kebechet installation."""
         with self._session_scope() as session:
             active_installations = (


### PR DESCRIPTION
## Related Issues and Dependencies
Related to both https://github.com/thoth-station/mi-scheduler/pull/58
and https://github.com/thoth-station/common/pull/1054#discussion_r534069107

## This introduces a breaking change

- [ ] Yes
- [X] No

## This should yield a new module release

- [X] Yes
- [ ] No

## This Pull Request implements
New `def get_kebechet_github_installations_active(self) -> List[str]:` method

## Description
The method returns the string list of all the repositories that have active kebechet installations