### PR TITLE
Correct error in sorting, use sort()

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -3749,7 +3749,7 @@ class GraphDatabase(SQLBase):
         if requirements is not None:
             python_package_requirements = self._create_python_package_requirement(session, requirements)
             # Create unique hash for requirements to go into PythonRequirements
-            requirements_ids = [int(ppr.id) for ppr in python_package_requirements].sorted()
+            requirements_ids = [int(ppr.id) for ppr in python_package_requirements].sort()
             requirements_hash = self._create_fuzzy_hash(requirements_ids)
 
             if is_external:
@@ -3782,7 +3782,7 @@ class GraphDatabase(SQLBase):
                 session, requirements_lock, software_environment=software_environment, sync_only_entity=is_external
             )
             # Create unique hash for requirements locked to go to PythonRequirementsLock
-            requirements_lock_ids = [int(ppv.id) for ppv in python_package_versions].sorted()
+            requirements_lock_ids = [int(ppv.id) for ppv in python_package_versions].sort()
             requirements_lock_hash = self._create_fuzzy_hash(requirements_lock_ids)
 
             if is_external:


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

```
 8296.267032623291, "process": 1, "message": "No s2i flag stated in the adviser result 'adviser-77ba12c8'"}
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.66895335Z Traceback (most recent call last):
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.670488294Z   File "app.py", line 237, in <module>
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.67076467Z     cli()
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.67076467Z   File "/opt/app-root/lib64/python3.8/site-packages/click/core.py", line 829, in __call__
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.670938295Z     return self.main(*args, **kwargs)
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.670938295Z   File "/opt/app-root/lib64/python3.8/site-packages/click/core.py", line 782, in main
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.671068882Z     rv = self.invoke(ctx)
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.671068882Z   File "/opt/app-root/lib64/python3.8/site-packages/click/core.py", line 1066, in invoke
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.67125891Z     return ctx.invoke(self.callback, **ctx.params)
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.67125891Z   File "/opt/app-root/lib64/python3.8/site-packages/click/core.py", line 610, in invoke
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.671384915Z     return callback(*args, **kwargs)
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.671384915Z   File "app.py", line 211, in cli
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.671456727Z     _do_sync(
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.671456727Z   File "app.py", line 110, in _do_sync
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.671530628Z     stats = sync_documents(
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.671530628Z   File "/opt/app-root/lib64/python3.8/site-packages/thoth/storages/sync.py", line 631, in sync_documents
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.672443384Z {"name": "sentry_sdk.errors", "levelname": "DEBUG", "module": "transport", "lineno": 222, "funcname": "_send_event", "created": 1607088021.6720366, "asctime": "2020-12-04 13:20:21,672", "msecs": 672.0366477966309, "relative_created": 8893.590450286865, "process": 1, "message": "Sending event, type:null level:error event_id:bab825dbae60425e8f482858452bab7b project:1298083 host:sentry.io"}
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.673424416Z     stats_change = handler(
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.673424416Z   File "/opt/app-root/lib64/python3.8/site-packages/thoth/storages/sync.py", line 81, in sync_adviser_documents
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.673638506Z     graph.sync_adviser_result(document)
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.673638506Z   File "/opt/app-root/lib64/python3.8/site-packages/thoth/storages/graph/postgres.py", line 4989, in sync_adviser_result
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.674544185Z     external_software_stack = self._create_python_software_stack(
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.674544185Z   File "/opt/app-root/lib64/python3.8/site-packages/thoth/storages/graph/postgres.py", line 3752, in _create_python_software_stack
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.675642994Z     requirements_ids = [int(ppr.id) for ppr in python_package_requirements].sorted()
adviser-77ba12c8-2675617601: 2020-12-04T13:20:21.675642994Z AttributeError: 'list' object has no attribute 'sorted'2020-12-04T13:20:21.675661654Z 

```
## This introduces a breaking change

- [ ] Yes
- [ ] No

## This should yield a new module release

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

… Explain your changes.

## Description

<!--- Describe your changes in detail -->