### PR TITLE
Use proper naming convention of type 6

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -3476,7 +3476,15 @@ class GraphDatabase(SQLBase):
             return False
 
     def get_active_kebechet_github_installations_repos_count_all(self) -> int:
-        """Return the count of active repos with Kebechet installation."""
+        """Return the count of active repos with Kebechet installation.
+        
+        Example:
+        >>> from thoth.storages import GraphDatabase
+        >>> graph = GraphDatabase()
+        >>> graph.connect()
+        >>> graph.get_active_kebechet_github_installations_repos_count_all()
+        165
+        """
         with self._session_scope() as session:
             count = (
                 session.query(KebechetGithubAppInstallations)

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -3475,7 +3475,7 @@ class GraphDatabase(SQLBase):
                 return True
             return False
 
-    def get_kebechet_github_installations_count_per_is_active(self) -> int:
+    def get_active_kebechet_github_installations_repos_count_all(self) -> int:
         """Return the count of active repos with Kebechet installation."""
         with self._session_scope() as session:
             count = (


### PR DESCRIPTION
## Related Issues and Dependencies
See discussion here https://github.com/thoth-station/storages/pull/2134#discussion_r535906381

## This introduces a breaking change

- [X] Yes
- [ ] No

All the applications that are using this method should reference it with its new name

## This should yield a new module release

- [ ] Yes
- [X] No

## This Pull Request implements
Rename `get_kebechet_github_installations_count_per_is_active` to `get_active_kebechet_github_installations_repos_count_all` - the use of proper naming convention

## Description
 @pacospace wrote
> naming convention for get_kebechet_github_installations_count_per_is_active is not respected actually. Whatever is returning type number should be should have _count at the end => get_active_kebechet_github_installations_repos_count_all (Type six naming)