### PR TITLE
Add get_origin_count_per_source_type method

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -4203,9 +4203,9 @@ class GraphDatabase(SQLBase):
         Examples:
         >>> from thoth.storages import GraphDatabase
         >>> graph = GraphDatabase()
-        >>> graph.get_users_count_per_spurce_type()
+        >>> graph.get_origin_count_per_source_type()
         {'GITHUB_APP': 1570, 'KEBECHET': 48, 'JUPYTER_NOTEBOOK': 18, 'CLI': 513}
-        >>> graph.get_users_count_per_spurce_type(distinct=True)
+        >>> graph.get_origin_count_per_source_type(distinct=True)
         {'GITHUB_APP': 145, 'KEBECHET': 5, 'JUPYTER_NOTEBOOK': 2, 'CLI': 78}
         """
         with self._session_scope() as session:


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Related-To: https://github.com/thoth-station/metrics-exporter/issues/549

## This introduces a breaking change

- [ ] Yes
- [ ] No

## This should yield a new module release

- [x] Yes
- [ ] No

## Description

```
        """Retrieve number of users of adviser per source type.

        Examples:
        >>> from thoth.storages import GraphDatabase
        >>> graph = GraphDatabase()
        >>> graph.get_origin_count_per_source_type()
        {'GITHUB_APP': 1570, 'KEBECHET': 48, 'JUPYTER_NOTEBOOK': 18, 'CLI': 513}
        >>> graph.get_origin_count_per_source_type(distinct=True)
        {'GITHUB_APP': 145, 'KEBECHET': 5, 'JUPYTER_NOTEBOOK': 2, 'CLI': 78}
        """
```