### PR TITLE
Add queries and fix bug discovered

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -1781,7 +1781,13 @@ class GraphDatabase(SQLBase):
         return query
 
     def get_ecosystem_solver_all(self) -> int:
-        """Get all solvers."""
+        """Get all solvers.
+        Examples:
+        >>> from thoth.storages import GraphDatabase
+        >>> graph = GraphDatabase()
+        >>> graph.get_ecosystem_solver_all()
+        ['solver-fedora-31-py38', 'solver-fedora-32-py37', 'solver-fedora-32-py38', 'solver-ubi-8-py36']
+        """
         with self._session_scope() as session:
             query = self._construct_get_solver_query(
                 session,

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -1780,7 +1780,7 @@ class GraphDatabase(SQLBase):
 
         return query
 
-    def get_ecosystem_solver_all(self) -> int:
+    def get_ecosystem_solver_all(self) -> List[str]:
         """Get all solvers.
         Examples:
         >>> from thoth.storages import GraphDatabase
@@ -1802,8 +1802,7 @@ class GraphDatabase(SQLBase):
             query = self._construct_get_solver_query(
                 session,
             )
-            count = query.count()
-            return count
+            return query.count()
 
     def get_solver_documents_count_all(self) -> int:
         """Get number of solver documents synced into graph."""

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -1774,7 +1774,6 @@ class GraphDatabase(SQLBase):
         """Construct query to retrieve solvers."""
         query = (
             session.query(EcosystemSolver)
-            .filter(EcosystemSolver.os_name != 'rhel')   # Thoth considers rhel == ubi
             .distinct(EcosystemSolver.solver_name)
         )
 
@@ -4268,7 +4267,7 @@ class GraphDatabase(SQLBase):
             if source_type:
                 query = query.filter(AdviserRun.source_type == source_type)
 
-            query = query.offset(start_offset).limit(count)
+            # query = query.offset(start_offset).limit(count)
 
             document_ids = query.all()
 


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

Related-To: https://github.com/thoth-station/storages/issues/2196

```
solvers:
['solver-fedora-31-py37', 'solver-fedora-31-py38', 'solver-fedora-32-py37', 'solver-fedora-32-py38', 'solver-ubi-8-py36']
number:
5
```

The new queries will be used in metrics-exporter, not to look for solver from CM but from database. In this way we know which solvers are present in the database, because in this moment only two solvers are shown from CM but in reality we have data from more solvers already in the database. 

In this way we can see already if there is an inconsistency in the data stored.

Moreover when we show users the solvers we have we should return the number from database.

See SLI report of today:

Parameter | Current value | Change since last week | Measurement Unit
-- | -- | -- | --
Solved Learning Rate | 0 | -363 | packages/hour
Solved packages | 610615 | +17338 | packages
Number of Solvers | 2 | 0 |  
Security Learning Rate | 0 | 0 | packages/hour
SI analyzed packages | 156807 | 0 | packages

