### PR TITLE
fix: the arguments for the normalize_os_version function

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -4963,7 +4963,7 @@ class GraphDatabase(SQLBase):
                 os_name=map_os_name(
                     os_name
                 ),
-                os_version=normalize_os_version(os_version),
+                os_version=normalize_os_version(os_name, os_version),
                 python_version=python_version,
             )
 


### PR DESCRIPTION
fix: the arguments for the normalize_os_version function
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/graph-sync-job/issues/557

Basedon: https://github.com/thoth-station/common/blob/e9b1cf969aacd9b9eab892ba7bcc1624aa2af31e/thoth/common/helpers.py#L190