### PR TITLE
Sync unresolved packages from provenance checker report

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -5352,6 +5352,28 @@ class GraphDatabase(SQLBase):
                 user_software_stack_id=software_stack.id,
             )
 
+            # Mark down packages that were not solved and missed in provenance checker.
+
+            report = document["result"]["report"]
+
+            message_id = "MISSING-PACKAGE"
+
+            for package in report:
+
+                # Discover unresolved package matching the message ID
+                if package["id"] == message_id:
+
+                    python_package_version_entity = self._create_python_package_version(
+                        session,
+                        package_name=package["package_name"],
+                        package_version=package["package_version"].lstrip("=="),
+                        index_url=package["source"]["url"],
+                        os_name=None,
+                        os_version=None,
+                        python_version=None,
+                        sync_only_entity=True,
+                    )
+
     def sync_dependency_monkey_result(self, document: dict) -> None:
         """Sync reports of dependency monkey runs."""
         if "ERROR" in document["result"]["report"]:

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -5353,15 +5353,11 @@ class GraphDatabase(SQLBase):
             )
 
             # Mark down packages that were not solved and missed in provenance checker.
-
             report = document["result"]["report"]
 
-            message_id = "MISSING-PACKAGE"
-
             for package in report:
-
                 # Discover unresolved package matching the message ID
-                if package["id"] == message_id:
+                if package["id"] == "MISSING-PACKAGE":
 
                     python_package_version_entity = self._create_python_package_version(
                         session,


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

We implement similar logic present for adviser sync. This is important if for some reason unsolved messages sent by provenance checker might not be consumed or they are lost.

Related-To: https://github.com/thoth-station/thoth-application/issues/818#issuecomment-770759067

Tested using: `provenance-checker-210202075859-fc13440741027d96`

## This introduces a breaking change

- [ ] Yes
- [x] No

## This should yield a new module release

- [x] Yes
- [ ] No