### PR TITLE
Adjust query for user software stack

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -3945,22 +3945,18 @@ class GraphDatabase(SQLBase):
 
         return software_stack
 
-    def get_python_software_stack_count_all(self, software_stack_type: str, distinct: bool = False) -> int:
+    def get_python_software_stack_count_all(self, is_external: bool = False, software_stack_type: Optional[str] = None, distinct: bool = False) -> int:
         """Get number of Python software stacks available filtered by type."""
         with self._session_scope() as session:
-            query = session.query(PythonSoftwareStack.software_stack_type).filter(
-                PythonSoftwareStack.software_stack_type == software_stack_type
-            )
+            if is_external:
+                query = session.query(ExternalPythonSoftwareStack)
+            else:
+                query = session.query(PythonSoftwareStack.software_stack_type).filter(
+                    PythonSoftwareStack.software_stack_type == software_stack_type
+                )
 
-            if distinct:
-                return query.distinct().count()
-
-            return query.count()
-
-    def get_external_python_software_stack_count_all(self) -> int:
-        """Get number of User Python software stacks available."""
-        with self._session_scope() as session:
-            query = session.query(ExternalPythonSoftwareStack)
+                if distinct:
+                    return query.distinct().count()
 
             return query.count()
 

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -3957,6 +3957,13 @@ class GraphDatabase(SQLBase):
 
             return query.count()
 
+    def get_external_python_software_stack_count_all(self) -> int:
+        """Get number of User Python software stacks available."""
+        with self._session_scope() as session:
+            query = session.query(ExternalPythonSoftwareStack)
+
+            return query.count()
+
     def sync_inspection_result(self, document) -> None:
         """Sync the given inspection document into the graph database."""
         # Check if we have such performance model before creating any other records.


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

![Screenshot from 2021-02-03 09-43-38](https://user-images.githubusercontent.com/27498679/106720958-56f91980-6604-11eb-88b6-343ee943d7d9.png)


## This introduces a breaking change

- [ ] Yes
- [x] No

## This should yield a new module release

- [x] Yes
- [ ] No

## This Pull Request implements

Add query to correctly retrieve number of user software stacks. Recently we introduced ExternalPythonSoftwareStack table only for users, therefore the query currently used in metrics-exporter reports always 0.