### PR TITLE
Fix/avoid duplicate heads

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -358,15 +358,11 @@ class GraphDatabase(SQLBase):
 
     def get_table_alembic_version_head(self) -> str:
         """Get alembic version head from database table."""
-        from alembic.runtime import migration
+        query = f"SELECT * FROM alembic_version"
 
-        if not self.is_connected():
-            raise NotConnected("Cannot check schema: the adapter is not connected yet")
-
-        connection = self._engine.connect()
-        context = migration.MigrationContext.configure(connection)
-        current_rev = context.get_current_revision()
-        return current_rev
+        with self._session_scope() as session:
+            result = session.execute(query).fetchone()
+            return result[0]
 
     def is_schema_up2date(self) -> bool:
         """Check if the current schema is up2date with the one configured on database side."""


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

![Screenshot from 2021-03-19 16-58-59](https://user-images.githubusercontent.com/27498679/111821002-744b2400-88e2-11eb-96d7-cde552e9a1a6.png)

The old method sometimes expose two heads, which can trigger alarms that are not required.
This PR modify the method to retrieve database head, not using alembic version methods but directly querying the table in the datbaase.
