### PR TITLE
Introduce datetime filter to retrieve data from Ceph

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -84,5 +84,5 @@ class StorageBaseTest(ThothStoragesTest):
     def test_get_document_listing(self, adapter):
         """Test document listing for build logs stored on Ceph."""
         # Just check that the request is properly propagated.
-        flexmock(adapter.ceph).should_receive("get_document_listing").with_args().and_return([]).once()
-        assert list(adapter.get_document_listing()) == []
+        flexmock(adapter.ceph).should_receive("get_document_listing").with_args(filter_=None).and_return([]).once()
+        assert list(adapter.get_document_listing(datetime_=None)) == []

--- a/tests/test_result_base.py
+++ b/tests/test_result_base.py
@@ -82,7 +82,7 @@ class ResultBaseTest(StorageBaseTest):
 class TestResultBase(ResultBaseTest):
     """Test base class for result types.
 
-    We need to rename class to rename the class so it starts with Test prefix and is correctly picked by pytest.
+    We need to rename class so it starts with Test prefix and is correctly picked by pytest.
     We cannot directly use this class to derive from in result-specific adapters as pytest will run tests multiple
     times for it due to Test prefix. This is a simple workaround to avoid running tests multiple times.
     """

--- a/thoth/storages/buildlogs.py
+++ b/thoth/storages/buildlogs.py
@@ -20,6 +20,7 @@
 import hashlib
 import os
 import typing
+import datetime
 
 from .ceph import CephStore
 from .base import StorageBase
@@ -76,6 +77,7 @@ class BuildLogsStore(StorageBase):
         """Iterate over results available in the Ceph."""
         return self.ceph.iterate_results()
 
-    def get_document_listing(self) -> typing.Generator[str, None, None]:
+    def get_document_listing(self, datetime_: typing.Optional[datetime.datetime] = None) -> typing.Generator[str, None, None]:
         """Get listing of documents stored on the Ceph."""
-        return self.ceph.get_document_listing()
+        filter_ = self.ceph.prefix + f"{self.ceph.prefix.split('/')[-2]}-{datetime_:%y%m%d}" if datetime_ else None
+        return self.ceph.get_document_listing(filter_=filter_)

--- a/thoth/storages/ceph.py
+++ b/thoth/storages/ceph.py
@@ -35,11 +35,12 @@ class CephStore(StorageBase):
         self,
         prefix,
         *,
-        host: str = None,
-        key_id: str = None,
-        secret_key: str = None,
-        bucket: str = None,
-        region: str = None,
+        host: typing.Optional[str] = None,
+        key_id: typing.Optional[str] = None,
+        secret_key: typing.Optional[str] = None,
+        bucket: typing.Optional[str] = None,
+        region: typing.Optional[str] = None,
+        use_document_id_prefix: bool = False,
     ):
         """Initialize adapter to Ceph.
 
@@ -53,8 +54,9 @@ class CephStore(StorageBase):
         self.region = region or os.getenv("THOTH_CEPH_REGION", None)
         self._s3 = None
         self.prefix = prefix
+        self.use_document_id_prefix = use_document_id_prefix or bool(int(os.getenv("THOTH_USING_FILE_ID_PREFIX", 0)))
 
-        if not self.prefix.endswith("/"):
+        if not self.use_document_id_prefix and not self.prefix.endswith("/"):
             self.prefix += "/"
 
     def get_document_listing(self) -> typing.Generator[str, None, None]:

--- a/thoth/storages/ceph.py
+++ b/thoth/storages/ceph.py
@@ -40,7 +40,7 @@ class CephStore(StorageBase):
         secret_key: typing.Optional[str] = None,
         bucket: typing.Optional[str] = None,
         region: typing.Optional[str] = None,
-        document_id_prefix: typing.Optional[str] = None,
+        file_id_prefix: typing.Optional[str] = None,
     ):
         """Initialize adapter to Ceph.
 
@@ -54,9 +54,9 @@ class CephStore(StorageBase):
         self.region = region or os.getenv("THOTH_CEPH_REGION", None)
         self._s3 = None
         self.prefix = prefix
-        self.document_id_prefix = document_id_prefix
+        self.file_id_prefix = file_id_prefix
 
-        if not self.document_id_prefix and not self.prefix.endswith("/"):
+        if not self.file_id_prefix and not self.prefix.endswith("/"):
             self.prefix += "/"
 
     def get_document_listing(self) -> typing.Generator[str, None, None]:

--- a/thoth/storages/ceph.py
+++ b/thoth/storages/ceph.py
@@ -58,9 +58,9 @@ class CephStore(StorageBase):
         if not self.prefix.endswith("/"):
             self.prefix += "/"
 
-    def get_document_listing(self, datetime_: typing.Optional[datetime.datetime] = None) -> typing.Generator[str, None, None]:
+    def get_document_listing(self, filter_: typing.Optional[str] = None) -> typing.Generator[str, None, None]:
         """Get listing of documents stored on the Ceph."""
-        prefix = self.prefix + f"{self.prefix.split('/')[-2]}-{datetime_:%y%m%d}" if datetime_ else self.prefix
+        prefix = filter_ if filter_ else self.prefix
         for obj in self._s3.Bucket(self.bucket).objects.filter(Prefix=prefix).all():
             yield obj.key[len(prefix) :]  # Ignore PycodestyleBear (E203)
 

--- a/thoth/storages/ceph.py
+++ b/thoth/storages/ceph.py
@@ -40,7 +40,7 @@ class CephStore(StorageBase):
         secret_key: typing.Optional[str] = None,
         bucket: typing.Optional[str] = None,
         region: typing.Optional[str] = None,
-        use_document_id_prefix: bool = False,
+        document_id_prefix: typing.Optional[str] = None,
     ):
         """Initialize adapter to Ceph.
 
@@ -54,9 +54,9 @@ class CephStore(StorageBase):
         self.region = region or os.getenv("THOTH_CEPH_REGION", None)
         self._s3 = None
         self.prefix = prefix
-        self.use_document_id_prefix = use_document_id_prefix or bool(int(os.getenv("THOTH_USING_FILE_ID_PREFIX", 0)))
+        self.document_id_prefix = document_id_prefix
 
-        if not self.use_document_id_prefix and not self.prefix.endswith("/"):
+        if not self.document_id_prefix and not self.prefix.endswith("/"):
             self.prefix += "/"
 
     def get_document_listing(self) -> typing.Generator[str, None, None]:

--- a/thoth/storages/result_base.py
+++ b/thoth/storages/result_base.py
@@ -89,7 +89,9 @@ class ResultStorageBase(StorageBase):
 
     def get_document_listing(self, datetime_: typing.Optional[datetime.datetime] = None) -> typing.Generator[str, None, None]:
         """Get listing of documents available in Ceph as a generator."""
-        for document_id in self.ceph.get_document_listing(datetime_=datetime_):
+        filter_ = self.ceph.prefix + f"{self.ceph.prefix.split('/')[-2]}-{datetime_:%y%m%d}"
+
+        for document_id in self.ceph.get_document_listing(filter_=filter_):
             # Filter out stored requests.
             if not document_id.endswith(".request"):
                 if datetime_:

--- a/thoth/storages/result_base.py
+++ b/thoth/storages/result_base.py
@@ -101,8 +101,7 @@ class ResultStorageBase(StorageBase):
 
     def get_document_count(self, datetime_: typing.Optional[datetime.datetime] = None) -> int:
         """Get number of documents present."""
-        filter_ = self.ceph.prefix + f"{self.ceph.prefix.split('/')[-2]}-{datetime_:%y%m%d}" if datetime_ else None
-        return len(tuple(self.get_document_listing(filter_=filter_)))
+        return len(tuple(self.get_document_listing(datetime_=datetime_)))
 
     def store_document(self, document: dict) -> str:
         """Store the given document in Ceph."""

--- a/thoth/storages/result_base.py
+++ b/thoth/storages/result_base.py
@@ -59,7 +59,7 @@ class ResultStorageBase(StorageBase):
 
         self.deployment_name = deployment_name or os.environ["THOTH_DEPLOYMENT_NAME"]
 
-        self.datetime_ = f"{datetime_:%y%m%d}"
+        self.datetime_ = f"{datetime_:%y%m%d}" if datetime_ else ""
 
         if self.datetime_:
             self.prefix = "{}/{}/{}/{}".format(

--- a/thoth/storages/result_base.py
+++ b/thoth/storages/result_base.py
@@ -58,7 +58,7 @@ class ResultStorageBase(StorageBase):
 
         self.deployment_name = deployment_name or os.environ["THOTH_DEPLOYMENT_NAME"]
 
-        self.document_id_prefix = document_id_prefix or os.environ["THOTH_FILE_ID_PREFIX"]
+        self.document_id_prefix = document_id_prefix
 
         if self.document_id_prefix:
             self.prefix = "{}/{}/{}/{}".format(
@@ -72,7 +72,7 @@ class ResultStorageBase(StorageBase):
             )
 
         self.ceph = CephStore(
-            self.prefix, host=host, key_id=key_id, secret_key=secret_key, bucket=bucket, region=region
+            self.prefix, host=host, key_id=key_id, secret_key=secret_key, bucket=bucket, region=region, document_id_prefix=document_id_prefix
         )
 
     @classmethod

--- a/thoth/storages/result_base.py
+++ b/thoth/storages/result_base.py
@@ -99,9 +99,10 @@ class ResultStorageBase(StorageBase):
                 else:
                     yield document_id
 
-    def get_document_count(self) -> int:
+    def get_document_count(self, datetime_: typing.Optional[datetime.datetime] = None) -> int:
         """Get number of documents present."""
-        return len(tuple(self.get_document_listing()))
+        filter_ = self.ceph.prefix + f"{self.ceph.prefix.split('/')[-2]}-{datetime_:%y%m%d}" if datetime_ else None
+        return len(tuple(self.get_document_listing(filter_=filter_)))
 
     def store_document(self, document: dict) -> str:
         """Store the given document in Ceph."""

--- a/thoth/storages/result_base.py
+++ b/thoth/storages/result_base.py
@@ -89,7 +89,7 @@ class ResultStorageBase(StorageBase):
 
     def get_document_listing(self, datetime_: typing.Optional[datetime.datetime] = None) -> typing.Generator[str, None, None]:
         """Get listing of documents available in Ceph as a generator."""
-        filter_ = self.ceph.prefix + f"{self.ceph.prefix.split('/')[-2]}-{datetime_:%y%m%d}"
+        filter_ = self.ceph.prefix + f"{self.ceph.prefix.split('/')[-2]}-{datetime_:%y%m%d}" if datetime_ else None
 
         for document_id in self.ceph.get_document_listing(filter_=filter_):
             # Filter out stored requests.

--- a/thoth/storages/result_base.py
+++ b/thoth/storages/result_base.py
@@ -59,7 +59,7 @@ class ResultStorageBase(StorageBase):
 
         self.deployment_name = deployment_name or os.environ["THOTH_DEPLOYMENT_NAME"]
 
-        self.datetime_ = f"{datetime_:%y%m%d}" if datetime_ else ""
+        self.datetime_ = f"{datetime_:%y%m%d}" if datetime_ else None
 
         if self.datetime_:
             self.prefix = "{}/{}/{}/{}".format(
@@ -74,6 +74,7 @@ class ResultStorageBase(StorageBase):
             self.prefix = "{}/{}/{}".format(
                 prefix or os.environ["THOTH_CEPH_BUCKET_PREFIX"], self.deployment_name, self.RESULT_TYPE
             )
+
 
         self.ceph = CephStore(
             self.prefix, host=host, key_id=key_id, secret_key=secret_key, bucket=bucket, region=region, file_id_prefix=datetime_


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

Fixes: https://github.com/thoth-station/storages/issues/2272

## This introduces a breaking change

- [ ] Yes
- [x] No

## This should yield a new module release

- [ ] Yes
- [x] No

## This Pull Request implements
```
import datetime
from thoth.storages import AdvisersResultsStore

adviser = AdvisersResultsStore(
    datetime_= datetime.datetime.utcnow() - datetime.timedelta(days=50)
)

adviser.connect()

for idd in adviser.get_document_listing():
    print(idd)

[fmurdaca@pc-7 16:47:08 ~/work/aicoe/storages](introduce-document-id-prefix)$ pipenv run python3 test_ceph.py 
210216
adviser-210216182351-6ccbc250e532f9f8
adviser-210216182958-c578f62785eb8761
adviser-210216200858-1b2480815dc96a69
adviser-210216223227-ce381787ded17b0a
adviser-210216223307-577727b37bb17f7d
adviser-210216223403-de9afa93319b716b
```
