### PR TITLE
missing model import for ExternalPythonSoftwareStack

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -70,6 +70,7 @@ from .models import EcosystemSolver
 from .models import ExternalHardwareInformation
 from .models import ExternalPythonRequirements
 from .models import ExternalPythonRequirementsLock
+from .models import ExternalPythonSoftwareStack
 from .models import ExternalSoftwareEnvironment
 from .models import HardwareInformation
 from .models import InspectionRun


### PR DESCRIPTION
## Related Issues and Dependencies

```NameError: name 'ExternalPythonSoftwareStack' is not defined```

