### PR TITLE
Sync solver name, no mapping required in solver sync logic

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -5091,7 +5091,7 @@ class GraphDatabase(SQLBase):
                 ecosystem="python",
                 solver_name=solver_name,
                 solver_version=solver_version,
-                os_name=map_os_name(os_name),
+                os_name=os_name,
                 os_version=normalize_os_version(os_name, os_version),
                 python_version=python_version,
             )


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Related-To: https://github.com/thoth-station/storages/issues/2196
Sync solver name, no mapping required in solver sync logic

we don't have rhel solver names
we don't need to map from ubi to rhel if solver name has ubi