### PR TITLE
Adjust/Add kebechet managers queries

### DIFF
--- a/thoth/storages/graph/enums.py
+++ b/thoth/storages/graph/enums.py
@@ -79,3 +79,14 @@ class PlatformEnum(Enum):
     """Class for platform enum."""
 
     LINUX_X86_64 = "linux-x86_64"
+
+
+class KebechetManagerEnum(Enum):
+    """Class for Kebechet manager enum."""
+
+    info_manager = 1
+    pipfile_requirements_manager = 2
+    update_manager = 3
+    version_manager = 4
+    thoth_advise_manager = 5
+    thoth_provenance_manager = 6

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -3706,7 +3706,7 @@ class GraphDatabase(SQLBase):
     def get_kebechet_github_installations_active_managers_count_all(
         self,
         kebechet_manager: str,
-    ) -> list:
+    ) -> int:
         """Return the number of repos with specific manager active.
 
         :rtype: int


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Related-To: https://github.com/thoth-station/metrics-exporter/issues/559

- Improved speed for `get_kebechet_github_installations_active_managers` query
- Introduced `get_kebechet_github_installations_active_managers_count_all` query for metrics
