### PR TITLE
Fix import enums

### DIFF
--- a/thoth/storages/graph/__init__.py
+++ b/thoth/storages/graph/__init__.py
@@ -19,3 +19,4 @@
 
 
 from .postgres import GraphDatabase
+from .enums import KebechetManagerEnum


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

```
  File "/home/fmurdaca/work/aicoe/storages/thoth/storages/__init__.py", line 31, in <module>
    from .graph import GraphDatabase
  File "/home/fmurdaca/work/aicoe/storages/thoth/storages/graph/__init__.py", line 22, in <module>
    from .enum import KebechetManagerEnum
ModuleNotFoundError: No module named 'thoth.storages.graph.enum'
```

## This introduces a breaking change

- [ ] Yes
- [x] No

## This should yield a new module release

- [x] Yes
- [ ] No

## This Pull Request implements

Fix issue in import of enums
