### PR TITLE
Improve performance of the unsolved Python packages query

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -1270,12 +1270,14 @@ class GraphDatabase(SQLBase):
     ) -> Query:
         """Construct query for unsolved Python packages versions functions, the query is not executed."""
         index_url = self.normalize_python_index_url(index_url)
-        rules_association = session.query(PythonPackageVersionEntityRulesAssociation.python_package_version_entity_id)
         query = session.query(PythonPackageVersionEntity).filter(
             PythonPackageVersionEntity.package_version.isnot(None),
-            PythonPackageVersionEntity.id.notin_(rules_association),
             PythonPackageIndex.url.isnot(None),
             PythonPackageIndex.enabled.is_(True),
+        )
+
+        query = query.join(PythonPackageVersionEntityRulesAssociation, isouter=True).filter(
+            PythonPackageVersionEntityRulesAssociation.python_package_version_entity_id.is_(None)
         )
 
         if package_name is not None:


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## This should yield a new module release

- [x] Yes

## This Pull Request implements

As observed during ingestion, the performance of unsolved query used in graph-refresh-job significantly dropped with more data ingested. After digging into this, the issue seems to be in the rules association that resulted in a sequential scan across the whole table of rules (that has few thousand entries) for each package we ingested. Naturally, this grows significantly. The optimization uses LEFT OUTER JOIN to speed up the query. I tested this query in the stage environment - currently, the query finishes in ~3 seconds (in opposite to hours).