### PR TITLE
Add distinct option to method get_python_package_version_import_packages_all

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -7047,7 +7047,9 @@ class GraphDatabase(SQLBase):
 
             return [{"package_name": i[1], "package_version": i[2], "location": i[0]} for i in query.all()]
 
-    def get_python_package_version_import_packages_all(self, import_name: str) -> List[Dict[str, str]]:
+    def get_python_package_version_import_packages_all(
+        self, import_name: str, distinct: bool = False
+    ) -> List[Dict[str, str]]:
         """Retrieve Python package name for the given import package name."""
         with self._session_scope() as session:
             query = (
@@ -7062,6 +7064,10 @@ class GraphDatabase(SQLBase):
                     PythonPackageVersion.package_name, PythonPackageVersion.package_version, PythonPackageIndex.url
                 )
             )
+
+            if distinct:
+                query = query.distinct()
+
             result = [{"package_name": i[0], "package_version": i[1], "index_url": i[2]} for i in query.all()]
 
             if not result:


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

This is required for whatprovides method in thamos:
![Screenshot from 2021-11-18 14-35-44](https://user-images.githubusercontent.com/27498679/142425201-cb9a4c4a-1b22-49da-9273-6630867c32b9.png)

Currently giving multiple results of same packages because of the runtime environment degree of freedom.

