### PR TITLE
Add methods to purge old documents and store them on Ceph

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -6751,7 +6751,6 @@ class GraphDatabase(SQLBase):
         self, *, os_name: Optional[str] = None, os_version: Optional[str] = None, python_version: Optional[str] = None
     ) -> int:
         """Store and purge to be deleted solver documents to Ceph"""
-        self.connect()
         solver_store = SolverResultsStore()
         solver_store.connect()
 
@@ -6777,7 +6776,6 @@ class GraphDatabase(SQLBase):
         self, *, end_datetime: Optional[str] = None, adviser_version: Optional[str] = None
     ) -> int:
         """Store and purge to be deleted adviser documents to Ceph"""
-        self.connect()
         adviser_store = AdvisersResultsStore()
         adviser_store.connect()
 
@@ -6814,7 +6812,6 @@ class GraphDatabase(SQLBase):
         self, *, end_datetime: Optional[str] = None, package_extract_version: Optional[str] = None
     ) -> int:
         """Store and purge to be deleted package extract documents to Ceph"""
-        self.connect()
         package_extract_store = AnalysisResultsStore()
         package_extract_store.connect()
 

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -6820,8 +6820,8 @@ class GraphDatabase(SQLBase):
         target_store.connect()
 
         with self._session_scope() as session:
-            query = session.query(PackageExtractRun.package_extract_version).with_entities(
-                PackageExtractRun.package_extract_version
+            query = session.query(PackageExtractRun.analysis_document_id).with_entities(
+                PackageExtractRun.analysis_document_id
             )
 
             if end_datetime:

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -60,8 +60,8 @@ from thoth.python import Pipfile
 from thoth.python import PipfileLock
 from thoth.common.helpers import format_datetime
 from thoth.common.helpers import datetime2datetime_str
+from thoth.common.helpers import normalize_os_version
 from thoth.common import OpenShift
-from thoth.common import normalize_os_version
 from thoth.common import map_os_name
 from thoth.common.enums import ThothAdviserIntegrationEnum
 
@@ -4950,7 +4950,7 @@ class GraphDatabase(SQLBase):
                 conditions.append(EcosystemSolver.os_name == os_name)
 
             if os_version:
-                os_version = OpenShift.normalize_os_version(os_name, os_version)
+                os_version = normalize_os_version(os_name, os_version)
                 conditions.append(EcosystemSolver.os_version == os_version)
 
             if python_version:

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -6773,7 +6773,7 @@ class GraphDatabase(SQLBase):
         return deleted_solver_documents_count
 
     def purge_adviser_documents(
-        self, *, end_datetime: Optional[str] = None, adviser_version: Optional[str] = None
+        self, *, end_datetime: Optional[datetime] = None, adviser_version: Optional[str] = None
     ) -> int:
         """Store and purge to be deleted adviser documents to Ceph"""
         adviser_store = AdvisersResultsStore()
@@ -6809,7 +6809,7 @@ class GraphDatabase(SQLBase):
         return deleted_adviser_documents_count
 
     def purge_package_extract_documents(
-        self, *, end_datetime: Optional[str] = None, package_extract_version: Optional[str] = None
+        self, *, end_datetime: Optional[datetime] = None, package_extract_version: Optional[str] = None
     ) -> int:
         """Store and purge to be deleted package extract documents to Ceph"""
         package_extract_store = AnalysisResultsStore()

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -59,6 +59,7 @@ from thoth.python import PackageVersion
 from thoth.python import Pipfile
 from thoth.python import PipfileLock
 from thoth.common.helpers import format_datetime
+from thoth.common.helpers import datetime2datetime_str
 from thoth.common import OpenShift
 from thoth.common import normalize_os_version
 from thoth.common import map_os_name
@@ -176,6 +177,7 @@ from ..exceptions import DatabaseNotInitialized
 from ..exceptions import DistutilsKeyNotKnown
 from ..exceptions import SortTypeQueryError
 from ..exceptions import CudaVersionDoesNotMatch
+from ..ceph import CephStore
 
 
 # Name of environment variables are long
@@ -6744,6 +6746,108 @@ class GraphDatabase(SQLBase):
             )
 
         return self._process_bloat_data_results(tables=tables)
+
+    def purge_solver_documents(
+        self, *, os_name: Optional[str] = None, os_version: Optional[str] = None, python_version: Optional[str] = None
+    ) -> int:
+        """Store and purge to be deleted solver documents to Ceph"""
+        self.connect()
+        solver_store = SolverResultsStore()
+        solver_store.connect()
+
+        target_prefix = f"{solver_store.ceph.prefix.rsplit('/', maxsplit=1)[0]}/solver-purge-{datetime2datetime_str()}/"
+        target_store = CephStore(prefix=target_prefix)
+        target_store.connect()
+
+        solver_document_ids = self.get_solver_run_document_ids_all(
+            os_version=os_version, os_name=os_name, python_version=python_version
+        )
+
+        deleted_solver_documents_count = 0
+
+        for solver_document_id in solver_document_ids:
+            document = solver_store.retrieve_document(document_id=solver_document_id)
+            target_store.store_document(document, document_id=solver_document_id)
+            solver_store.ceph.delete(object_key=solver_document_id)
+            deleted_solver_documents_count += self.delete_solver_result(solver_document_id=solver_document_id)
+
+        return deleted_solver_documents_count
+
+    def purge_adviser_documents(
+        self, *, end_datetime: Optional[str] = None, adviser_version: Optional[str] = None
+    ) -> int:
+        """Store and purge to be deleted adviser documents to Ceph"""
+        self.connect()
+        adviser_store = AdvisersResultsStore()
+        adviser_store.connect()
+
+        target_prefix = (
+            f"{adviser_store.ceph.prefix.rsplit('/', maxsplit=1)[0]}/adviser-purge-{datetime2datetime_str()}/"
+        )
+        target_store = CephStore(prefix=target_prefix)
+        target_store.connect()
+
+        with self._session_scope() as session:
+            query = session.query(AdviserRun.adviser_document_id).with_entities(AdviserRun.adviser_document_id)
+
+            if end_datetime:
+                date_filter = self._create_date_filter(end_datetime)
+                query = query.filter(AdviserRun.datetime < date_filter)
+
+            if adviser_version:
+                query = query.filter(AdviserRun.adviser_version == adviser_version)
+
+            adviser_document_ids = query.all()
+            adviser_document_ids = [obj[0] for obj in adviser_document_ids]
+
+        deleted_adviser_documents_count = 0
+
+        for adviser_document_id in adviser_document_ids:
+            document = adviser_store.retrieve_document(document_id=adviser_document_id)
+            target_store.store_document(document, document_id=adviser_document_id)
+            adviser_store.ceph.delete(object_key=adviser_document_id)
+            deleted_adviser_documents_count += self.delete_adviser_result(adviser_document_id=adviser_document_id)
+
+        return deleted_adviser_documents_count
+
+    def purge_package_extract_documents(
+        self, *, end_datetime: Optional[str] = None, package_extract_version: Optional[str] = None
+    ) -> int:
+        """Store and purge to be deleted package extract documents to Ceph"""
+        self.connect()
+        package_extract_store = AnalysisResultsStore()
+        package_extract_store.connect()
+
+        target_prefix = f"{package_extract_store.ceph.prefix.rsplit('/', maxsplit=1)[0]}/package-extract-purge-{datetime2datetime_str()}/"
+        target_store = CephStore(prefix=target_prefix)
+        target_store.connect()
+
+        with self._session_scope() as session:
+            query = session.query(PackageExtractRun.package_extract_version).with_entities(
+                PackageExtractRun.package_extract_version
+            )
+
+            if end_datetime:
+                date_filter = self._create_date_filter(end_datetime)
+                query = query.filter(PackageExtractRun.datetime < date_filter)
+
+            if package_extract_version:
+                query = query.filter(PackageExtractRun.package_extract_version == package_extract_version)
+
+            package_extract_document_ids = query.all()
+            package_extract_document_ids = [obj[0] for obj in package_extract_document_ids]
+
+        deleted_package_extract_documents_count = 0
+
+        for package_extract_document_id in package_extract_document_ids:
+            document = package_extract_store.retrieve_document(document_id=package_extract_document_id)
+            target_store.store_document(document, document_id=package_extract_document_id)
+            package_extract_store.ceph.delete(object_key=package_extract_document_id)
+            deleted_package_extract_documents_count += self.delete_analysis_result(
+                analysis_document_id=package_extract_document_id
+            )
+
+        return deleted_package_extract_documents_count
 
     def delete_solved(self, *, os_name: str, os_version: str, python_version: str) -> int:
         """Delete corresponding solver data."""


### PR DESCRIPTION
## Related Issues and Dependencies

Related to [#1516 on thoth-application](https://github.com/thoth-station/thoth-application/issues/1516)

## This introduces a breaking change

- [ ] Yes
- [ ] No

## This should yield a new module release

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Add methods to purge old adviser, solver and package extract documents and to store them to Ceph for future use, that will match the commands implemented on the purge-job repo.
