### PR TITLE
Allow syncing non-Thoth env variables from package-extract resul

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -5223,21 +5223,16 @@ class GraphDatabase(SQLBase):
     @staticmethod
     def _package_extract_get_env_vars(
         document: Dict[str, Any],
-    ) -> Tuple[Dict[str, str], Dict[str, str]]:
+    ) -> Dict[str, str]:
         """Obtain environment variables present in the container image."""
         result = {}
-        result_no_thoth = {}
 
         for entry in (document["result"].get("skopeo-inspect") or {}).get("Env") or []:
-            if entry.startswith(("THAMOS_", "THOTH_")):
+            if entry.startswith(("THAMOS_", "THOTH_")) or entry in ("IMAGE_NAME", "IMAGE_VERSION"):
                 env_name, env_val = entry.split("=", maxsplit=1)
                 result[env_name] = env_val
 
-            if entry in ["IMAGE_NAME", "IMAGE_VERSION"]:
-                env_name, env_val = entry.split("=", maxsplit=1)
-                result_no_thoth[env_name] = env_val
-
-        return result, result_no_thoth
+        return result
 
     def sync_analysis_result(self, document: dict) -> None:
         """Sync the given analysis result to the graph database."""
@@ -5287,7 +5282,7 @@ class GraphDatabase(SQLBase):
                         python_version[2:3] + "." + python_version[3:]
                     )  # take first digit and put . after it
 
-            env_vars, external_env_vars = self._package_extract_get_env_vars(document)
+            env_vars = self._package_extract_get_env_vars(document)
 
             software_environment, _ = sw_class.get_or_create(
                 session,
@@ -5299,8 +5294,8 @@ class GraphDatabase(SQLBase):
                 os_version=os_version,
                 thoth_s2i_image_name=env_vars.get("THOTH_S2I_NAME"),
                 thoth_s2i_image_version=env_vars.get("THOTH_S2I_VERSION"),
-                env_image_name=external_env_vars.get("IMAGE_NAME"),
-                env_image_tag=external_env_vars.get("IMAGE_TAG"),
+                env_image_name=env_vars.get("IMAGE_NAME"),
+                env_image_tag=env_vars.get("IMAGE_TAG"),
                 cuda_version=cuda_nvcc_version or cuda_found_in_file_version,
                 environment_type=environment_type,
             )


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

software environment table columns (env_image_name and env_image_tag) entries were always empty


Example from a v1.3.0 package extract result:

```
"Env": [
        "PATH=/opt/app-root/src/.local/bin/:/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
        "container=oci",
        "SUMMARY=Thoth's Source-to-Image for Python 3.8 applications",
        "DESCRIPTION=Thoth's Source-to-Image for Python 3.8 applications. This toolchain is based on Red Hat UBI8. It includes pipenv.",
        "STI_SCRIPTS_URL=image:///usr/libexec/s2i",
        "STI_SCRIPTS_PATH=/usr/libexec/s2i",
        "APP_ROOT=/opt/app-root",
        "HOME=/opt/app-root/src",
        "PLATFORM=el8",
        "NODEJS_VER=14",
        "PYTHON_VERSION=3.8",
        "PYTHONUNBUFFERED=1",
        "PYTHONIOENCODING=UTF-8",
        "LC_ALL=en_US.UTF-8",
        "LANG=en_US.UTF-8",
        "PIP_NO_CACHE_DIR=off",
        "BASH_ENV=/opt/app-root/etc/scl_enable",
        "ENV=/opt/app-root/etc/scl_enable",
        "PROMPT_COMMAND=. /opt/app-root/etc/scl_enable",
        "THOTH_S2I_NAME=quay.io/thoth-station/s2i-thoth-ubi8-py38",
        "THOTH_S2I_VERSION=0.29.0",
        "THAMOS_NO_PROGRESSBAR=1",
        "THAMOS_NO_EMOJI=1",
        "MICROPIPENV_NO_LOCKFILE_PRINT=0",
        "MICROPIPENV_NO_LOCKFILE_WRITE=0",
        "IMAGE_NAME=quay.io/thoth-station/s2i-generic-data-science-notebook",
        "IMAGE_TAG=v0.0.5",
        "GIT_REPO_NAME=s2i-generic-data-science-notebook",
        "THAMOS_RUNTIME_ENVIRONMENT=ps-cv-pytorch",
        "THOTH_ADVISE=0",
        "THOTH_ERROR_FALLBACK=1",
        "THOTH_DRY_RUN=1",
        "THAMOS_DEBUG=0",
        "THAMOS_VERBOSE=1",
        "THOTH_PROVENANCE_CHECK=0",
        "JUPYTER_ENABLE_LAB=true",
        "ENABLE_MICROPIPENV=1",
        "UPGRADE_PIP_TO_LATEST=1"
      ],
```