### PR TITLE
Extend get_software_environments_all query to provide also package_extract_run id and datetime.

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -2831,7 +2831,7 @@ class GraphDatabase(SQLBase):
                 'image_sha': 'bcf4fa447e5dc889015afb4d3c54ef4a3aaddc3260fce072311602df34ffac3c',
                 'os_name': 'rhel',
                 'os_version': '8',
-                'package_extract_run_id': 'package-extract-211215162259-33c8d9c730b775eb',
+                'package_extract_document_id': 'package-extract-211215162259-33c8d9c730b775eb',
                 'python_version': '3.9',
                 'thoth_s2i_image_name': 'quay.io/thoth-station/s2i-thoth-ubi8-py39',
                 'thoth_s2i_image_version': '0.32.3'
@@ -2904,7 +2904,7 @@ class GraphDatabase(SQLBase):
                         "image_sha": r[5],
                         "os_name": r[6],
                         "os_version": r[7],
-                        "package_extract_run_id": r[11],
+                        "package_extract_document_id": r[11],
                         "python_version": r[8],
                         "thoth_s2i_image_name": r[9],
                         "thoth_s2i_image_version": r[10],

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -2799,6 +2799,7 @@ class GraphDatabase(SQLBase):
     def get_software_environments_all(
         self,
         is_external: bool = False,
+        convert_datetime: bool = True,
         *,
         start_offset: int = 0,
         count: Optional[int] = DEFAULT_COUNT,
@@ -2896,7 +2897,7 @@ class GraphDatabase(SQLBase):
                 processed_results.append(
                     {
                         "cuda_version": r[0],
-                        "datetime": format_datetime(r[12]),
+                        "datetime": r[12] if not convert_datetime else format_datetime(r[12]),
                         "env_image_name": r[1],
                         "env_image_tag": r[2],
                         "environment_name": r[3],

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -2896,7 +2896,7 @@ class GraphDatabase(SQLBase):
                 processed_results.append(
                     {
                         "cuda_version": r[0],
-                        "datetime": r[12],
+                        "datetime": format_datetime(r[12]),
                         "env_image_name": r[1],
                         "env_image_tag": r[2],
                         "environment_name": r[3],


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

Related-To: https://github.com/thoth-station/user-api/issues/1543