### PR TITLE
Instructions for accessing Thoth's public database on opf-datacatalog

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -446,3 +446,15 @@ After initialization, you are ready to retrieve data
 
     except NotFoundError:
         # File does not exist
+
+Accessing Thoth Data on the Operate-First Public Bucket
+=======================================================
+
+A public instance of Thoth's database is available on the `Operate-First Public Bucket
+<https://github.com/operate-first/apps/blob/master/docs/content/odh/trino/access_public_bucket.md>`__ for external contributors to start developing components of Thoth.
+
+Instructions for accessing the bucket are available in the `documentation
+<https://github.com/thoth-station/datasets#accessing-thoth-data-on-the-operate-first-public-bucket>`__ of the `thoth/datasets
+<https://github.com/thoth-station/datasets>`__ repository.
+
+Be careful not to store any confidential or valuable information in this bucket as its content can be wiped out at any time.


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/datasets/issues/32

## This introduces a breaking change

- [x] No

## This should yield a new module release

- [x] No

## This Pull Request implements

Instructions in docs to access the public Thoth database that will be published on `opf-datacatalog`.