### PR TITLE
Retrieve datetime of last synced solver

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -407,25 +407,24 @@ class GraphDatabase(SQLBase):
             return result[0]
 
     def get_last_solver_datetime(
-        self, os_name: Optional[str], os_version: Optional[str], python_version: Optional[str]
+        self, os_name: Optional[str] = None, os_version: Optional[str] = None, python_version: Optional[str] = None
     ) -> datetime:
         """Get the datetime of the last solver run synced in the database."""
         with self._session_scope() as session:
-            result = session.query(func.max(Solved.datetime))
-
+            result = session.query(Solved.datetime)
             if os_name or os_version or python_version:
                 result = result.filter(Solved.ecosystem_solver_id == EcosystemSolver.id)
 
-            if os_name is not None:
-                result = result.filter(EcosystemSolver.os_name == os_name)
+                if os_name is not None:
+                    result = result.filter(EcosystemSolver.os_name == os_name)
 
-            if os_version is not None:
-                result = result.filter(EcosystemSolver.os_version == os_version)
+                if os_version is not None:
+                    result = result.filter(EcosystemSolver.os_version == os_version)
 
-            if python_version is not None:
-                result = result.filter(EcosystemSolver.python_version == python_version)
+                if python_version is not None:
+                    result = result.filter(EcosystemSolver.python_version == python_version)
 
-            return result.first()[0]
+        return max([datetime[0].isoformat() for datetime in result.all()])
 
     @staticmethod
     def normalize_python_package_name(package_name: str) -> str:

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -406,6 +406,14 @@ class GraphDatabase(SQLBase):
             result = session.execute(query).fetchone()
             return result[0]
 
+    def get_last_solver_datetime(self) -> datetime:
+        """Get the datetime of the last solver run synced in the database."""
+        query = "SELECT datetime FROM solver WHERE datetime IN (SELECT max(datetime) FROM solver)"
+
+        with self._session_scope() as session:
+            result = session.execute(query).fetchone()
+            return result[0]
+
     @staticmethod
     def normalize_python_package_name(package_name: str) -> str:
         """Normalize Python package name based on PEP-0503."""
@@ -7107,7 +7115,7 @@ class GraphDatabase(SQLBase):
     def purge_solver_documents(
         self, *, os_name: Optional[str] = None, os_version: Optional[str] = None, python_version: Optional[str] = None
     ) -> int:
-        """Store and purge to be deleted solver documents to Ceph"""
+        """Store and purge to be deleted solver documents to Ceph."""
         solver_store = SolverResultsStore()
         solver_store.connect()
 
@@ -7132,7 +7140,7 @@ class GraphDatabase(SQLBase):
     def purge_adviser_documents(
         self, *, end_datetime: Optional[datetime] = None, adviser_version: Optional[str] = None
     ) -> int:
-        """Store and purge to be deleted adviser documents to Ceph"""
+        """Store and purge to be deleted adviser documents to Ceph."""
         adviser_store = AdvisersResultsStore()
         adviser_store.connect()
 
@@ -7168,7 +7176,7 @@ class GraphDatabase(SQLBase):
     def purge_package_extract_documents(
         self, *, end_datetime: Optional[datetime] = None, package_extract_version: Optional[str] = None
     ) -> int:
-        """Store and purge to be deleted package extract documents to Ceph"""
+        """Store and purge to be deleted package extract documents to Ceph."""
         package_extract_store = AnalysisResultsStore()
         package_extract_store.connect()
 

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -409,7 +409,7 @@ class GraphDatabase(SQLBase):
     def get_last_solver_datetime(self) -> datetime:
         """Get the datetime of the last solver run synced in the database."""
         with self._session_scope() as session:
-            result = session.query(func.max(Solved.datetime))
+            result = session.query(func.max(Solved.datetime)).first()
             return result[0]
 
     @staticmethod

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -406,10 +406,19 @@ class GraphDatabase(SQLBase):
             result = session.execute(query).fetchone()
             return result[0]
 
-    def get_last_solver_datetime(self) -> datetime:
+    def get_last_solver_datetime(
+        self, os_name: Optional[str], os_version: Optional[str], python_version: Optional[str]
+    ) -> datetime:
         """Get the datetime of the last solver run synced in the database."""
         with self._session_scope() as session:
-            result = session.query(func.max(Solved.datetime)).first()
+            result = (
+                session.query(func.max(Solved.datetime))
+                .filter(Solved.ecosystem_solver_id == EcosystemSolver.id)
+                .filter(EcosystemSolver.os_name == os_name)
+                .filet(EcosystemSolver.os_version == os_version)
+                .filter(EcosystemSolver.python_version == python_version)
+                .first()
+            )
             return result[0]
 
     @staticmethod

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -424,7 +424,7 @@ class GraphDatabase(SQLBase):
                 if python_version is not None:
                     result = result.filter(EcosystemSolver.python_version == python_version)
 
-        return datetime.strptime(max([datetime[0].isoformat() for datetime in result.all()]), "%Y-%m-%d %H:%M:%S.%f")
+        return max([datetime[0] for datetime in result.all()])
 
     @staticmethod
     def normalize_python_package_name(package_name: str) -> str:

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -411,15 +411,21 @@ class GraphDatabase(SQLBase):
     ) -> datetime:
         """Get the datetime of the last solver run synced in the database."""
         with self._session_scope() as session:
-            result = (
-                session.query(func.max(Solved.datetime))
-                .filter(Solved.ecosystem_solver_id == EcosystemSolver.id)
-                .filter(EcosystemSolver.os_name == os_name)
-                .filet(EcosystemSolver.os_version == os_version)
-                .filter(EcosystemSolver.python_version == python_version)
-                .first()
-            )
-            return result[0]
+            result = session.query(func.max(Solved.datetime))
+
+            if os_name or os_version or python_version:
+                result = result.filter(Solved.ecosystem_solver_id == EcosystemSolver.id)
+
+            if os_name is not None:
+                result = result.filter(EcosystemSolver.os_name == os_name)
+
+            if os_version is not None:
+                result = result.filter(EcosystemSolver.os_version == os_version)
+
+            if python_version is not None:
+                result = result.filter(EcosystemSolver.python_version == python_version)
+
+            return result.first()[0]
 
     @staticmethod
     def normalize_python_package_name(package_name: str) -> str:

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -424,7 +424,7 @@ class GraphDatabase(SQLBase):
                 if python_version is not None:
                     result = result.filter(EcosystemSolver.python_version == python_version)
 
-        return max([datetime[0].isoformat() for datetime in result.all()])
+        return datetime.strptime(max([datetime[0].isoformat() for datetime in result.all()]), "%Y-%m-%d %H:%M:%S.%f")
 
     @staticmethod
     def normalize_python_package_name(package_name: str) -> str:

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -408,10 +408,8 @@ class GraphDatabase(SQLBase):
 
     def get_last_solver_datetime(self) -> datetime:
         """Get the datetime of the last solver run synced in the database."""
-        query = "SELECT datetime FROM solver WHERE datetime IN (SELECT max(datetime) FROM solver)"
-
         with self._session_scope() as session:
-            result = session.execute(query).fetchone()
+            result = session.query(func.max(Solved.datetime))
             return result[0]
 
     @staticmethod


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/metrics-exporter/issues/822

## This introduces a breaking change

- No

## This should yield a new module release

- Yes

## This Pull Request implements

Implement a query to retrieve the datetime of the last solver synced in the database (see first acceptance criteria of https://github.com/thoth-station/metrics-exporter/issues/822)