### PR TITLE
Adjust query for metadata due to change in schema

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -251,7 +251,7 @@ class GraphDatabase(SQLBase):
             "supported_platform",
         ],
         "requires_external": [HasMetadataRequiresExternal, PythonPackageMetadataRequiresExternal, "requires_external"],
-        "project_url": [HasMetadataProjectUrl, PythonPackageMetadataProjectUrl, "project_url"],
+        "project_url": [HasMetadataProjectUrl, PythonPackageMetadataProjectUrl, ["label", "url"]],
         "provides_extra": [HasMetadataProvidesExtra, PythonPackageMetadataProvidesExtra, "optional_feature"],
     }
 
@@ -3684,7 +3684,14 @@ class GraphDatabase(SQLBase):
                     .filter(tables[0].python_package_metadata_id == python_package_metadata_id)
                     .join(tables[1])
                 ).with_entities(tables[1])
-                multi_value_results[key] = [getattr(v, tables[2]) for v in query.all()]
+                if isinstance(tables[2], list):
+                    multi_value_results[key] = []
+                    values = query.all()
+                    for v in values:
+                        parts = [getattr(v, t) for t in tables[2]]
+                        multi_value_results[key].append(",".join(parts))
+                else:
+                    multi_value_results[key].append([getattr(v, tables[2]) for v in query.all()])
 
             distutils_result = dict([(key, []) for key in ["requires_dist", "provides_dist", "obsolete_dist"]])
             multi_value_results.update(distutils_result)


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Depends-On: https://github.com/thoth-station/storages/pull/2568

```
graph = GraphDatabase()
graph.connect()
r = graph.get_python_package_version_metadata(
    package_name="flatbuffers", package_version="1.12", index_url="https://pypi.org/simple"
)

print(r)
```

```
{'author': 'FlatBuffers Contributors', 'author_email': 'me@rwinslow.com', 'download_url': None, 'home_page': 'https://google.github.io/flatbuffers/', 'keywords': None, 'license': 'Apache 2.0', 'maintainer': None, 'maintainer_email': None, 'metadata_version': '2.1', 'name': 'flatbuffers', 'summary': 'The FlatBuffers serialization format for Python', 'version': '1.12', 'requires_python': None, 'description': 'Python runtime library for use with the `Flatbuffers <https://google.github.io/flatbuffers/>`_ serialization format.\n\n\n', 'description_content_type': None, 'classifier': [['Intended Audience :: Developers', 'License :: OSI Approved :: Apache Software License', 'Operating System :: OS Independent', 'Programming Language :: Python', 'Programming Language :: Python :: 2', 'Programming Language :: Python :: 3', 'Topic :: Software Development :: Libraries :: Python Modules']], 'platform': [['UNKNOWN']], 'supported_platform': [[]], 'requires_external': [[]], 'project_url': ['Source, https://github.com/google/flatbuffers', 'Documentation, https://google.github.io/flatbuffers/'], 'provides_extra': [[]], 'requires_dist': [], 'provides_dist': [], 'obsolete_dist': []}
```
