### PR TITLE
Query datetime of last container image analysis synced in the database

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -426,6 +426,12 @@ class GraphDatabase(SQLBase):
 
         return max([datetime[0] for datetime in result.all()])
 
+    def get_last_image_datetime(self) -> datetime:
+        """Get the datetime of the last container image analysis synced in the database."""
+        with self._session_scope() as session:
+            result = session.query(func.max(PackageExtractRun.datetime))
+            return result.first()[0]
+
     @staticmethod
     def normalize_python_package_name(package_name: str) -> str:
         """Normalize Python package name based on PEP-0503."""

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -429,8 +429,8 @@ class GraphDatabase(SQLBase):
     def get_last_image_datetime(self) -> datetime:
         """Get the datetime of the last container image analysis synced in the database."""
         with self._session_scope() as session:
-            result = session.query(func.max(PackageExtractRun.datetime))
-            return result.first()[0]
+            result = session.query(PackageExtractRun.datetime)
+            return max([datetime[0] for datetime in result.all()])
 
     @staticmethod
     def normalize_python_package_name(package_name: str) -> str:

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -426,7 +426,7 @@ class GraphDatabase(SQLBase):
 
         return max([datetime[0] for datetime in result.all()])
 
-    def get_last_image_datetime(self) -> datetime:
+    def get_last_analysis_datetime(self) -> datetime:
         """Get the datetime of the last container image analysis synced in the database."""
         with self._session_scope() as session:
             result = session.query(PackageExtractRun.datetime)


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/metrics-exporter/issues/822 :
- [ ] optionally, we can do the same for container image analyses to see if we have containerized environments properly analyzed and synced

## This introduces a breaking change

- No

## This should yield a new module release

- Yes

## This Pull Request implements

Query the datetime of the last container image analysis synced in the database. Options could be added to filter the container images similarly to solver documents with `os_name`, `os_version` and `python_version`.