### PR TITLE
Increase max_wal_size in postgres config

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,8 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
-
+    command: >
+      -c max_wal_size=2GB
   pgweb:
     image: docker.io/sosedoff/pgweb
     container_name: pgweb


### PR DESCRIPTION
## This introduces a breaking change

- No

## This should yield a new module release

- No

## This Pull Request implements

Increase the `max_wal_size` parameter in postgres config to 2GB to avoid error linked to checkpoints occurring too frequently.
