### PR TITLE
update metadata.id instead of passing it to 'create_ppv'

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -4761,8 +4761,11 @@ class GraphDatabase(SQLBase):
             os_version=os_version,
             python_version=python_version,
             entity_id=entity.id,
-            python_package_metadata_id=python_package_metadata_id,
         )
+
+        # including this value in "get_or_create" will cause errors because it is not part of a unique entry
+        if python_package_metadata_id:
+            python_package_version.python_package_metadata_id = python_package_metadata_id
 
         return python_package_version
 


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/integration-tests/issues/250

## This introduces a breaking change

- [ ] Yes
- [x] No

## This should yield a new module release

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

When new solver docs are synced they can update package metadata resulting in a new `metadata` row with a unique id. When this is passed to `_get_or_create` along with the other values an IntegrityError is raised because the other params already define a unique entry. However, no entry with the exact **kwargs is found so an error is raised. In this PR I removed the package_metadata_id from the original `_create...` query and then added it using an update statement below.