### PR TITLE
added ordering to python versions endpoint

### DIFF
--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -1086,9 +1086,17 @@ class GraphDatabase(SQLBase):
             )
 
             if order_by == "ASC":
-                query = query.order_by(text("string_to_array(regexp_replace(package_version, '[^0-9.]+|(?<=\d{4})(\d+)', '', 'g'), '.', '')::int[] ASC"))
+                query = query.order_by(
+                    text(
+                        "string_to_array(regexp_replace(package_version, '[^0-9.]+|(?<=\d{4})(\d+)', '', 'g'), '.', '')::int[] ASC"
+                    )
+                )
             elif order_by == "DESC":
-                query = query.order_by(text("string_to_array(regexp_replace(package_version, '[^0-9.]+|(?<=\d{4})(\d+)', '', 'g'), '.', '')::int[] DESC"))
+                query = query.order_by(
+                    text(
+                        "string_to_array(regexp_replace(package_version, '[^0-9.]+|(?<=\d{4})(\d+)', '', 'g'), '.', '')::int[] DESC"
+                    )
+                )
 
             query = query.offset(start_offset).limit(count)
 

--- a/thoth/storages/graph/postgres.py
+++ b/thoth/storages/graph/postgres.py
@@ -45,6 +45,7 @@ from packaging.version import parse as parse_version
 from sqlalchemy import create_engine
 from sqlalchemy import desc
 from sqlalchemy import func
+from sqlalchemy import text
 from sqlalchemy import exists
 from sqlalchemy import and_
 from sqlalchemy import tuple_
@@ -1055,6 +1056,7 @@ class GraphDatabase(SQLBase):
         *,
         start_offset: int = 0,
         count: Optional[int] = DEFAULT_COUNT,
+        order_by: Optional[str] = None,
         os_name: Optional[str] = None,
         os_version: Optional[str] = None,
         python_version: Optional[str] = None,
@@ -1082,6 +1084,11 @@ class GraphDatabase(SQLBase):
                 python_version=python_version,
                 is_missing=is_missing,
             )
+
+            if order_by == "ASC":
+                query = query.order_by(text("string_to_array(regexp_replace(package_version, '[^0-9.]+|(?<=\d{4})(\d+)', '', 'g'), '.', '')::int[] ASC"))
+            elif order_by == "DESC":
+                query = query.order_by(text("string_to_array(regexp_replace(package_version, '[^0-9.]+|(?<=\d{4})(\d+)', '', 'g'), '.', '')::int[] DESC"))
 
             query = query.offset(start_offset).limit(count)
 


### PR DESCRIPTION
## Related Issues and Dependencies
https://github.com/thoth-station/user-api/issues/1670

## This introduces a breaking change

- [X] No

The new param is optional so older uses will work the same unless using the new param.

## This should yield a new module release

- [X] Yes

## This Pull Request implements

Added a new param to `get_solved_python_package_versions_all` called `order_by`. It optionally takes either `ASC` or `DESC` as input which orders the output by the version number.

## Description

It specifically will apply the postgresql query `ORDER BY string_to_array(regexp_replace(package_version, '[^0-9.]+|(?<=\d{4})(\d+)', '', 'g'), '.', '')::int[]`:
- regex replace function `regexp_replace(package_version, '[^0-9.]+|(?<=\d{4})(\d+)', '', 'g')` replaces all non numbers exclduing decimals with "", it also replaces any numbers that have more than 4 digits (to prevent integer overflow) ex) `1234567890 -> 1234`
     - ex) `"1.2.0rc12243432134"` -> `"1.2.01224"`
-  `string_to_array('1.2.01224', '.', '')` will split the string by delimiter=`.`, where empty strings are converted to NULL. ex)`"1.2."` -> `["1", "2", NULL]`
     - ex) `1.2.01224` -> `["1", "2", "1224"]`
- `::int[]` will cast the strings to numbers
- `ASC` | `DESC` will order by ascending or decending