### PR TITLE
Fix method to iterate on thoth files

### DIFF
--- a/thoth/storages/result_base.py
+++ b/thoth/storages/result_base.py
@@ -86,15 +86,16 @@ class ResultStorageBase(StorageBase):
         """Connect the given storage adapter."""
         self.ceph.connect()
 
-    @staticmethod
     def _iter_dates_prefix_addition(
+        self,
         start_date: date,
         end_date: typing.Optional[date] = None,
         *,
-        prefix: str = RESULT_TYPE,
         include_end_date: bool = False,
     ) -> typing.Generator[str, None, None]:
         """Create prefix based on dates supplied."""
+        prefix = self.RESULT_TYPE
+
         if end_date is None:
             end_date = date.today() + timedelta(days=1)  # Today inclusively.
         elif end_date < start_date:


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

While checking why slo-reporter was not able to provide analysis of adviser results. I dig into advise-reproter logic and verified that it was not able to read adviser files, due to a method in thoth-storages.

Iterating over files in a bucket gives empty lists even if files exist because the prefix used to identify them is using a default value which is not updated. The value RESULT_TYPE is fixed: https://github.com/thoth-station/storages/blob/3a365887b3c32fac910d568d277a7c3b8ddd6048/thoth/storages/result_base.py#L94

for example using adviser results store method iterates over the following prefix

`data/aws-prod/adviser/-220310`

which does not identify any files.

This PR modify the method to use the `self.RESULT_TYPE` instead which is assigned when instatiating the class for the different components.

Alternative solution: do not modify the method, but assign the prefix to be self.RESULT_TYPE when `_iter_dates_prefix_addition` is used.

