### PR TITLE
Increase default S3 timeout to 180s for retrieving data from Ceph

### DIFF
--- a/thoth/storages/ceph.py
+++ b/thoth/storages/ceph.py
@@ -146,7 +146,7 @@ class CephStore(StorageBase):
         # signature version is needed to connect to new regions which
         # support only v4
         self._s3 = session.resource(
-            "s3", config=botocore.client.Config(signature_version="s3v4"), endpoint_url=self.host
+            "s3", config=botocore.client.Config(connect_timeout=180, signature_version="s3v4"), endpoint_url=self.host
         )
         # Ceph returns 403 on this call, let's assume the bucket exists.
         # self._create_bucket_if_needed()


### PR DESCRIPTION
## This introduces a breaking change

- No

## This should yield a new module release

- Yes

## This Pull Request implements
Retrieving a large list of objects from an S3 bucket can cause a gateway timeout error because the default `botocore` client configuration sets the timeout to 60 seconds. Increasing the timeout to 180 seconds will allow for more objects to be retrieved without a failure. As an example, getting a hundred Amun inspections from the `opf-datacatalog` public bucket takes approximately 2 minutes, which exceeds the default timeout value.