### PR TITLE
Randomize solver document listing

### DIFF
--- a/thoth/storages/__init__.py
+++ b/thoth/storages/__init__.py
@@ -49,7 +49,6 @@ from .sync import sync_provenance_checker_documents
 from .sync import sync_security_indicators_documents
 from .sync import sync_solver_documents
 from .sync import HANDLERS_MAPPING
-from .sync import RANDOMIZE_LISTING
 
 
 __name__ = "thoth-storages"
@@ -90,5 +89,4 @@ __all__ = [
     WorkflowLogsStore.__name__,
     "HANDLERS_MAPPING",
     "RESULT_SCHEMA",
-    "RANDOMIZE_LISTING",
 ]

--- a/thoth/storages/__init__.py
+++ b/thoth/storages/__init__.py
@@ -49,6 +49,7 @@ from .sync import sync_provenance_checker_documents
 from .sync import sync_security_indicators_documents
 from .sync import sync_solver_documents
 from .sync import HANDLERS_MAPPING
+from .sync import RANDOMIZE_LISTING
 
 
 __name__ = "thoth-storages"
@@ -89,4 +90,5 @@ __all__ = [
     WorkflowLogsStore.__name__,
     "HANDLERS_MAPPING",
     "RESULT_SCHEMA",
+    "RANDOMIZE_LISTING",
 ]

--- a/thoth/storages/sync.py
+++ b/thoth/storages/sync.py
@@ -39,6 +39,7 @@ from .solvers import SolverResultsStore
 from .graph import GraphDatabase
 
 _LOGGER = logging.getLogger(__name__)
+RANDOMIZE_LISTING = os.getenv("RANDOMIZE_LISTING", 0)
 
 
 def sync_adviser_documents(
@@ -99,11 +100,8 @@ def sync_solver_documents(
     graceful: bool = False,
     graph: Optional[GraphDatabase] = None,
     is_local: bool = False,
-    randomize_listing: Optional[bool] = False,
 ) -> tuple:
     """Sync solver documents into graph."""
-    document_listing = list(solver_store.get_document_listing())
-
     if is_local and not document_ids:
         raise ValueError(
             "Cannot sync documents from local directory without explicitly specifying a list of documents to be synced"
@@ -117,10 +115,13 @@ def sync_solver_documents(
         solver_store = SolverResultsStore()
         solver_store.connect()
 
-    if randomize_listing:
+    if not document_ids:
+        document_listing = list(solver_store.get_document_listing())
+
+    if RANDOMIZE_LISTING:
         if document_ids:
             random.shuffle(document_ids)
-        elif document_listing:
+        else:
             random.shuffle(document_listing)
 
     processed, synced, skipped, failed = 0, 0, 0, 0

--- a/thoth/storages/sync.py
+++ b/thoth/storages/sync.py
@@ -25,6 +25,7 @@ from typing import Tuple
 from typing import List
 from typing import Optional
 from pathlib import Path
+from random import random
 
 from .analyses import AnalysisResultsStore
 from .advisers import AdvisersResultsStore
@@ -98,8 +99,11 @@ def sync_solver_documents(
     graceful: bool = False,
     graph: Optional[GraphDatabase] = None,
     is_local: bool = False,
+    randomize_listing: Optional[bool] = False,
 ) -> tuple:
     """Sync solver documents into graph."""
+    document_listing = list(solver_store.get_document_listing())
+
     if is_local and not document_ids:
         raise ValueError(
             "Cannot sync documents from local directory without explicitly specifying a list of documents to be synced"
@@ -113,8 +117,14 @@ def sync_solver_documents(
         solver_store = SolverResultsStore()
         solver_store.connect()
 
+    if randomize_listing:
+        if document_ids:
+            random.shuffle(document_ids)
+        elif document_listing:
+            random.shuffle(document_listing)
+
     processed, synced, skipped, failed = 0, 0, 0, 0
-    for document_id in document_ids or solver_store.get_document_listing():
+    for document_id in document_ids or document_listing:
         processed += 1
         if force or not graph.solver_document_id_exists(os.path.basename(document_id)):
             try:

--- a/thoth/storages/sync.py
+++ b/thoth/storages/sync.py
@@ -39,7 +39,7 @@ from .solvers import SolverResultsStore
 from .graph import GraphDatabase
 
 _LOGGER = logging.getLogger(__name__)
-RANDOMIZE_LISTING = os.getenv("RANDOMIZE_LISTING", 0)
+_RANDOMIZE_LISTING = bool(int(os.getenv("THOTH_STORAGES_RANDOMIZE_LISTING", 0)))
 
 
 def sync_adviser_documents(
@@ -63,17 +63,13 @@ def sync_adviser_documents(
         adviser_store = AdvisersResultsStore()
         adviser_store.connect()
 
-    if not document_ids:
-        document_listing = list(adviser_store.get_document_listing())
+    listing = list(adviser_store.get_document_listing()) or document_ids
 
-    if RANDOMIZE_LISTING:
-        if document_ids:
-            random.shuffle(document_ids)
-        else:
-            random.shuffle(document_listing)
+    if _RANDOMIZE_LISTING:
+        random.shuffle(listing)
 
     processed, synced, skipped, failed = 0, 0, 0, 0
-    for document_id in document_ids or document_listing:
+    for document_id in listing:
         processed += 1
 
         if force or not graph.adviser_document_id_exist(os.path.basename(document_id)):
@@ -124,17 +120,13 @@ def sync_solver_documents(
         solver_store = SolverResultsStore()
         solver_store.connect()
 
-    if not document_ids:
-        document_listing = list(solver_store.get_document_listing())
+    listing = list(solver_store.get_document_listing()) or document_ids
 
-    if RANDOMIZE_LISTING:
-        if document_ids:
-            random.shuffle(document_ids)
-        else:
-            random.shuffle(document_listing)
+    if _RANDOMIZE_LISTING:
+        random.shuffle(listing)
 
     processed, synced, skipped, failed = 0, 0, 0, 0
-    for document_id in document_ids or document_listing:
+    for document_id in listing:
         processed += 1
         if force or not graph.solver_document_id_exists(os.path.basename(document_id)):
             try:
@@ -184,17 +176,13 @@ def sync_revsolver_documents(
         revsolver_store = RevSolverResultsStore()
         revsolver_store.connect()
 
-    if not document_ids:
-        document_listing = list(revsolver_store.get_document_listing())
+    listing = list(revsolver_store.get_document_listing()) or document_ids
 
-    if RANDOMIZE_LISTING:
-        if document_ids:
-            random.shuffle(document_ids)
-        else:
-            random.shuffle(document_listing)
+    if _RANDOMIZE_LISTING:
+        random.shuffle(listing)
 
     processed, synced, skipped, failed = 0, 0, 0, 0
-    for document_id in document_ids or document_listing:
+    for document_id in listing:
         processed += 1
         try:
             if is_local:
@@ -242,17 +230,13 @@ def sync_analysis_documents(
         analysis_store = AnalysisResultsStore()
         analysis_store.connect()
 
-    if not document_ids:
-        document_listing = list(analysis_store.get_document_listing())
+    listing = list(analysis_store.get_document_listing()) or document_ids
 
-    if RANDOMIZE_LISTING:
-        if document_ids:
-            random.shuffle(document_ids)
-        else:
-            random.shuffle(document_listing)
+    if _RANDOMIZE_LISTING:
+        random.shuffle(listing)
 
     processed, synced, skipped, failed = 0, 0, 0, 0
-    for document_id in document_ids or document_listing:
+    for document_id in listing:
         processed += 1
 
         if force or not graph.analysis_document_id_exist(os.path.basename(document_id)):
@@ -303,17 +287,13 @@ def sync_provenance_checker_documents(
         provenance_check_store = ProvenanceResultsStore()
         provenance_check_store.connect()
 
-    if not document_ids:
-        document_listing = list(provenance_check_store.get_document_listing())
+    listing = list(provenance_check_store.get_document_listing()) or document_ids
 
-    if RANDOMIZE_LISTING:
-        if document_ids:
-            random.shuffle(document_ids)
-        else:
-            random.shuffle(document_listing)
+    if _RANDOMIZE_LISTING:
+        random.shuffle(listing)
 
     processed, synced, skipped, failed = 0, 0, 0, 0
-    for document_id in document_ids or document_listing:
+    for document_id in listing:
         processed += 1
 
         if force or not graph.provenance_checker_document_id_exist(os.path.basename(document_id)):
@@ -366,17 +346,13 @@ def sync_dependency_monkey_documents(
         dependency_monkey_reports_store = DependencyMonkeyReportsStore()
         dependency_monkey_reports_store.connect()
 
-    if not document_ids:
-        document_listing = list(dependency_monkey_reports_store.get_document_listing())
+    listing = list(dependency_monkey_reports_store.get_document_listing()) or document_ids
 
-    if RANDOMIZE_LISTING:
-        if document_ids:
-            random.shuffle(document_ids)
-        else:
-            random.shuffle(document_listing)
+    if _RANDOMIZE_LISTING:
+        random.shuffle(listing)
 
     processed, synced, skipped, failed = 0, 0, 0, 0
-    for document_id in document_ids or document_listing:
+    for document_id in listing:
         processed += 1
 
         if force or not graph.dependency_monkey_document_id_exists(os.path.basename(document_id)):
@@ -426,17 +402,13 @@ def sync_inspection_documents(
         graph = GraphDatabase()
         graph.connect()
 
-    if not document_ids:
-        document_listing = list(InspectionStore.iter_inspections())
+    listing = list(InspectionStore.iter_inspections()) or document_ids
 
-    if RANDOMIZE_LISTING:
-        if document_ids:
-            random.shuffle(document_ids)
-        else:
-            random.shuffle(document_listing)
+    if _RANDOMIZE_LISTING:
+        random.shuffle(listing)
 
     processed, synced, skipped, failed = 0, 0, 0, 0
-    for inspection_document_id in document_ids or document_listing:
+    for inspection_document_id in listing:
 
         if not is_local:
             results = []
@@ -537,17 +509,13 @@ def sync_security_indicators_documents(
         graph = GraphDatabase()
         graph.connect()
 
-    if not document_ids:
-        document_listing = list(SecurityIndicatorsResultsStore.iter_security_indicators())
+    listing = list(SecurityIndicatorsResultsStore.iter_security_indicators()) or document_ids
 
-    if RANDOMIZE_LISTING:
-        if document_ids:
-            random.shuffle(document_ids)
-        else:
-            random.shuffle(document_listing)
+    if _RANDOMIZE_LISTING:
+        random.shuffle(listing)
 
     processed, synced, skipped, failed = 0, 0, 0, 0
-    for security_indicator_id in document_ids or document_listing:
+    for security_indicator_id in listing:
 
         processed += 1
 

--- a/thoth/storages/sync.py
+++ b/thoth/storages/sync.py
@@ -63,8 +63,17 @@ def sync_adviser_documents(
         adviser_store = AdvisersResultsStore()
         adviser_store.connect()
 
+    if not document_ids:
+        document_listing = list(adviser_store.get_document_listing())
+
+    if RANDOMIZE_LISTING:
+        if document_ids:
+            random.shuffle(document_ids)
+        else:
+            random.shuffle(document_listing)
+
     processed, synced, skipped, failed = 0, 0, 0, 0
-    for document_id in document_ids or adviser_store.get_document_listing():
+    for document_id in document_ids or document_listing:
         processed += 1
 
         if force or not graph.adviser_document_id_exist(os.path.basename(document_id)):
@@ -175,8 +184,17 @@ def sync_revsolver_documents(
         revsolver_store = RevSolverResultsStore()
         revsolver_store.connect()
 
+    if not document_ids:
+        document_listing = list(revsolver_store.get_document_listing())
+
+    if RANDOMIZE_LISTING:
+        if document_ids:
+            random.shuffle(document_ids)
+        else:
+            random.shuffle(document_listing)
+
     processed, synced, skipped, failed = 0, 0, 0, 0
-    for document_id in document_ids or revsolver_store.get_document_listing():
+    for document_id in document_ids or document_listing:
         processed += 1
         try:
             if is_local:
@@ -224,8 +242,17 @@ def sync_analysis_documents(
         analysis_store = AnalysisResultsStore()
         analysis_store.connect()
 
+    if not document_ids:
+        document_listing = list(analysis_store.get_document_listing())
+
+    if RANDOMIZE_LISTING:
+        if document_ids:
+            random.shuffle(document_ids)
+        else:
+            random.shuffle(document_listing)
+
     processed, synced, skipped, failed = 0, 0, 0, 0
-    for document_id in document_ids or analysis_store.get_document_listing():
+    for document_id in document_ids or document_listing:
         processed += 1
 
         if force or not graph.analysis_document_id_exist(os.path.basename(document_id)):
@@ -276,8 +303,17 @@ def sync_provenance_checker_documents(
         provenance_check_store = ProvenanceResultsStore()
         provenance_check_store.connect()
 
+    if not document_ids:
+        document_listing = list(provenance_check_store.get_document_listing())
+
+    if RANDOMIZE_LISTING:
+        if document_ids:
+            random.shuffle(document_ids)
+        else:
+            random.shuffle(document_listing)
+
     processed, synced, skipped, failed = 0, 0, 0, 0
-    for document_id in document_ids or provenance_check_store.get_document_listing():
+    for document_id in document_ids or document_listing:
         processed += 1
 
         if force or not graph.provenance_checker_document_id_exist(os.path.basename(document_id)):
@@ -330,8 +366,17 @@ def sync_dependency_monkey_documents(
         dependency_monkey_reports_store = DependencyMonkeyReportsStore()
         dependency_monkey_reports_store.connect()
 
+    if not document_ids:
+        document_listing = list(dependency_monkey_reports_store.get_document_listing())
+
+    if RANDOMIZE_LISTING:
+        if document_ids:
+            random.shuffle(document_ids)
+        else:
+            random.shuffle(document_listing)
+
     processed, synced, skipped, failed = 0, 0, 0, 0
-    for document_id in document_ids or dependency_monkey_reports_store.get_document_listing():
+    for document_id in document_ids or document_listing:
         processed += 1
 
         if force or not graph.dependency_monkey_document_id_exists(os.path.basename(document_id)):
@@ -381,8 +426,17 @@ def sync_inspection_documents(
         graph = GraphDatabase()
         graph.connect()
 
+    if not document_ids:
+        document_listing = list(InspectionStore.iter_inspections())
+
+    if RANDOMIZE_LISTING:
+        if document_ids:
+            random.shuffle(document_ids)
+        else:
+            random.shuffle(document_listing)
+
     processed, synced, skipped, failed = 0, 0, 0, 0
-    for inspection_document_id in document_ids or InspectionStore.iter_inspections():
+    for inspection_document_id in document_ids or document_listing:
 
         if not is_local:
             results = []
@@ -483,8 +537,17 @@ def sync_security_indicators_documents(
         graph = GraphDatabase()
         graph.connect()
 
+    if not document_ids:
+        document_listing = list(SecurityIndicatorsResultsStore.iter_security_indicators())
+
+    if RANDOMIZE_LISTING:
+        if document_ids:
+            random.shuffle(document_ids)
+        else:
+            random.shuffle(document_listing)
+
     processed, synced, skipped, failed = 0, 0, 0, 0
-    for security_indicator_id in document_ids or SecurityIndicatorsResultsStore.iter_security_indicators():
+    for security_indicator_id in document_ids or document_listing:
 
         processed += 1
 

--- a/thoth/storages/sync.py
+++ b/thoth/storages/sync.py
@@ -63,10 +63,10 @@ def sync_adviser_documents(
         adviser_store = AdvisersResultsStore()
         adviser_store.connect()
 
-    listing = list(adviser_store.get_document_listing()) or document_ids
+    listing = adviser_store.get_document_listing() or document_ids
 
     if _RANDOMIZE_LISTING:
-        random.shuffle(listing)
+        random.shuffle(list(listing))
 
     processed, synced, skipped, failed = 0, 0, 0, 0
     for document_id in listing:
@@ -120,10 +120,10 @@ def sync_solver_documents(
         solver_store = SolverResultsStore()
         solver_store.connect()
 
-    listing = list(solver_store.get_document_listing()) or document_ids
+    listing = solver_store.get_document_listing() or document_ids
 
     if _RANDOMIZE_LISTING:
-        random.shuffle(listing)
+        random.shuffle(list(listing))
 
     processed, synced, skipped, failed = 0, 0, 0, 0
     for document_id in listing:
@@ -176,10 +176,10 @@ def sync_revsolver_documents(
         revsolver_store = RevSolverResultsStore()
         revsolver_store.connect()
 
-    listing = list(revsolver_store.get_document_listing()) or document_ids
+    listing = revsolver_store.get_document_listing() or document_ids
 
     if _RANDOMIZE_LISTING:
-        random.shuffle(listing)
+        random.shuffle(list(listing))
 
     processed, synced, skipped, failed = 0, 0, 0, 0
     for document_id in listing:
@@ -230,10 +230,10 @@ def sync_analysis_documents(
         analysis_store = AnalysisResultsStore()
         analysis_store.connect()
 
-    listing = list(analysis_store.get_document_listing()) or document_ids
+    listing = analysis_store.get_document_listing() or document_ids
 
     if _RANDOMIZE_LISTING:
-        random.shuffle(listing)
+        random.shuffle(list(listing))
 
     processed, synced, skipped, failed = 0, 0, 0, 0
     for document_id in listing:
@@ -287,10 +287,10 @@ def sync_provenance_checker_documents(
         provenance_check_store = ProvenanceResultsStore()
         provenance_check_store.connect()
 
-    listing = list(provenance_check_store.get_document_listing()) or document_ids
+    listing = provenance_check_store.get_document_listing() or document_ids
 
     if _RANDOMIZE_LISTING:
-        random.shuffle(listing)
+        random.shuffle(list(listing))
 
     processed, synced, skipped, failed = 0, 0, 0, 0
     for document_id in listing:
@@ -346,10 +346,10 @@ def sync_dependency_monkey_documents(
         dependency_monkey_reports_store = DependencyMonkeyReportsStore()
         dependency_monkey_reports_store.connect()
 
-    listing = list(dependency_monkey_reports_store.get_document_listing()) or document_ids
+    listing = dependency_monkey_reports_store.get_document_listing() or document_ids
 
     if _RANDOMIZE_LISTING:
-        random.shuffle(listing)
+        random.shuffle(list(listing))
 
     processed, synced, skipped, failed = 0, 0, 0, 0
     for document_id in listing:
@@ -402,10 +402,10 @@ def sync_inspection_documents(
         graph = GraphDatabase()
         graph.connect()
 
-    listing = list(InspectionStore.iter_inspections()) or document_ids
+    listing = InspectionStore.iter_inspections() or document_ids
 
     if _RANDOMIZE_LISTING:
-        random.shuffle(listing)
+        random.shuffle(list(listing))
 
     processed, synced, skipped, failed = 0, 0, 0, 0
     for inspection_document_id in listing:
@@ -509,10 +509,10 @@ def sync_security_indicators_documents(
         graph = GraphDatabase()
         graph.connect()
 
-    listing = list(SecurityIndicatorsResultsStore.iter_security_indicators()) or document_ids
+    listing = SecurityIndicatorsResultsStore.iter_security_indicators() or document_ids
 
     if _RANDOMIZE_LISTING:
-        random.shuffle(listing)
+        random.shuffle(list(listing))
 
     processed, synced, skipped, failed = 0, 0, 0, 0
     for security_indicator_id in listing:


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/thoth-application/issues/2513
- [ ] make sure the [sync method in thoth-storages ](https://github.com/thoth-station/storages/blob/d58f8a72787aebcc20a2ff702dc087d1286384dc/thoth/storages/sync.py#L117)can randomize document listing so that we can run multiple sync jobs in parallel

## This introduces a breaking change

- No

Randomizing the solver documents listing is optional.

## This should yield a new module release

- Yes

## This Pull Request implements

Introduce an optional argument to the [`sync_solver_documents`](https://github.com/thoth-station/storages/blob/d58f8a72787aebcc20a2ff702dc087d1286384dc/thoth/storages/sync.py#L95) method in storages to randomize solver document listing.
