### PR TITLE
Retrieve TTL of cached documents

### DIFF
--- a/thoth/storages/ceph.py
+++ b/thoth/storages/ceph.py
@@ -101,12 +101,7 @@ class CephStore(StorageBase):
 
     def retrieve_document_last_modification_date(self, object_key: str) -> datetime:
         """Retrieve the last modification date of a document from S3."""
-        try:
-            return self._s3.Object(self.bucket, f"{self.prefix}{object_key}").get()["LastModified"]
-        except botocore.exceptions.ClientError as exc:
-            if exc.response["Error"]["Code"] in ("404", "NoSuchKey"):
-                raise NotFoundError("Failed to retrieve object, object {!r} does not exist".format(object_key)) from exc
-            raise
+        return self._s3.Object(self.bucket, f"{self.prefix}{object_key}").get()["LastModified"]
 
     def iterate_results(self, prefix_addition: typing.Optional[str] = None) -> typing.Generator[tuple, None, None]:
         """Iterate over results available in the Ceph."""

--- a/thoth/storages/ceph.py
+++ b/thoth/storages/ceph.py
@@ -24,8 +24,6 @@ import typing
 import boto3
 import botocore
 
-from datetime import datetime
-
 from .base import StorageBase
 from .exceptions import NotFoundError
 
@@ -99,9 +97,9 @@ class CephStore(StorageBase):
                 raise NotFoundError("Failed to retrieve object, object {!r} does not exist".format(object_key)) from exc
             raise
 
-    def retrieve_document_last_modification_date(self, object_key: str) -> datetime:
-        """Retrieve the last modification date of a document from S3."""
-        return self._s3.Object(self.bucket, f"{self.prefix}{object_key}").get()["LastModified"]
+    def retrieve_document_attr(self, object_key: str, attr: str) -> typing.Any:
+        """Retrieve the given attribute of a document from S3."""
+        return self._s3.Object(self.bucket, f"{self.prefix}{object_key}").get()[attr]
 
     def iterate_results(self, prefix_addition: typing.Optional[str] = None) -> typing.Generator[tuple, None, None]:
         """Iterate over results available in the Ceph."""

--- a/thoth/storages/ceph_cache.py
+++ b/thoth/storages/ceph_cache.py
@@ -43,8 +43,7 @@ class CephCache(ResultStorageBase):
         # Verify if the document is present in the cache
         self.retrieve_document_record(document_id)
 
-        # No timezone is indicated to calculate the present datetime on purpose to get the correct time delta
-        # regardless of the environment where the data is retrieved from (production or stage)
+        # Uses UTC time to be environment agnostic (no timezone)
         time_lived = (datetime.now() - self.ceph.retrieve_document_last_modification_date(document_id)).total_seconds()
 
         if time_lived <= 7200.0:

--- a/thoth/storages/ceph_cache.py
+++ b/thoth/storages/ceph_cache.py
@@ -44,9 +44,11 @@ class CephCache(ResultStorageBase):
         self.retrieve_document_record(document_id)
 
         # Uses UTC time to be environment agnostic (no timezone)
-        time_lived = (datetime.now() - self.ceph.retrieve_document_last_modification_date(document_id)).total_seconds()
+        time_lived = (
+            datetime.now() - self.ceph.retrieve_document_attr(object_key=document_id, attr="LastModified")
+        ).total_seconds()
 
-        if time_lived <= 7200.0:
+        if time_lived <= 14400.0:
             return time_lived
 
         return 0.0


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/storages/issues/2666

## This introduces a breaking change

- No

## This should yield a new module release

- Yes

## This Pull Request implements

Implement a method to retrieve the time to live of a cached document, considering S3 bucket timezones for different environments.
This implementation is based on the current documents caching time of 2 hours. 