### PR TITLE
Convert ceph datetime object to be offset-aware

### DIFF
--- a/thoth/storages/ceph_cache.py
+++ b/thoth/storages/ceph_cache.py
@@ -45,7 +45,10 @@ class CephCache(ResultStorageBase):
 
         # Uses UTC time to be environment agnostic (no timezone)
         time_lived = (
-            datetime.now() - self.ceph.retrieve_document_attr(object_key=document_id, attr="LastModified")
+            datetime.now()
+            - self.ceph.retrieve_document_attr(object_key=document_id, attr="LastModified").replace(
+                tzinfo=datetime.timezone.utc
+            )
         ).total_seconds()
 
         if time_lived <= 14400.0:


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/user-api/issues/1614
Fix required for https://github.com/thoth-station/user-api/pull/1798

## This introduces a breaking change

- No

## This should yield a new module release

- Yes

## This Pull Request implements

Convert `self.ceph.retrieve_document_attr(object_key=document_id, attr="LastModified")` object to an offset-aware datetime object to fix the diff between `datetime.now()` (offset-aware) and `self.ceph.retrieve_document_attr(object_key=document_id, attr="LastModified")` (offset-naive).
