### PR TITLE
:face_in_clouds: Fix the sync_documents formatting

### DIFF
--- a/thoth/storages/sync.py
+++ b/thoth/storages/sync.py
@@ -580,12 +580,14 @@ def sync_documents(
     >>> from thoth.storages.sync import sync_documents
     >>> sync_documents(["adviser-efa7213babd12911", "package-extract-f8e354d9597a1203"])
     """
+
+    handlers: Dict[str, List[str]] = dict()
     if document_ids:
-        handlers: Dict[str, List[str]] = dict.fromkeys(HANDLERS_MAPPING, [])
+        handlers = {key: [] for key in HANDLERS_MAPPING.keys()}
         assert handlers is not None
         for doc in document_ids:
             try:
-                handlers[doc[doc.rfind("/") + 1 : doc.rfind("-")]].append(doc)
+                handlers[doc[doc.rfind("/") + 1 : doc.find("-")]].append(doc)
                 # Basename for local syncs, document_id should not have slash otherwise.
             except KeyError:
                 error_msg = f"No handler defined for document identifier {doc}"
@@ -598,8 +600,9 @@ def sync_documents(
 
     stats = dict.fromkeys(HANDLERS_MAPPING, (0, 0, 0, 0))
     for handler, documents in (handlers or static_handlers).items():
-        stats[handler] = HANDLERS_MAPPING[handler](
-            documents, force=force, graceful=graceful, graph=graph, is_local=is_local
-        )
+        if documents != []:
+            stats[handler] = HANDLERS_MAPPING[handler](
+                documents, force=force, graceful=graceful, graph=graph, is_local=is_local
+            )
 
     return stats


### PR DESCRIPTION
Fix the sync_documents formatting
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/storages/issues/2750

## This introduces a breaking change

- [x] Yes
- [ ] No

## This should yield a new module release

- [x] Yes
- [ ] No

## Description

- Change `dict.fromkeys` to dict comprehension as dict.fromkeys behave weirdly when value is list.
More info: https://stackoverflow.com/questions/3000468/unwanted-behaviour-from-dict-fromkeys

- fix the handle assignment by changing the `doc.rfind` to `doc.find` , so it get correct prefix.
```
>>> x = "adviser-efa7213babd12911"
>>> x[x.rfind("/")+1: x.find("-")]
'adviser'
```

- we would only like to run sync handlers if the document is having value or None.